### PR TITLE
feat: add microsoft login screen

### DIFF
--- a/lib/features/autenticacion/presentacion/paginas/login_page.dart
+++ b/lib/features/autenticacion/presentacion/paginas/login_page.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:msal_flutter/msal_flutter.dart';
+
+/// Pantalla de inicio de sesión basada en Microsoft Entra.
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  late final PublicClientApplication _pca;
+
+  @override
+  void initState() {
+    super.initState();
+    // TODO: Reemplazar con el clientId real de la aplicación.
+    _pca = PublicClientApplication(
+      'REEMPLAZAR_CON_CLIENT_ID',
+      authority: 'https://login.microsoftonline.com/common',
+    );
+  }
+
+  Future<void> _signIn() async {
+    try {
+      await _pca.acquireTokenInteractive(scopes: const ['User.Read']);
+    } catch (e) {
+      // Manejar errores o cancelaciones del flujo de autenticación.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return Column(
+              children: [
+                const Spacer(),
+                Flexible(
+                  child: Align(
+                    alignment: Alignment.center,
+                    child:
+                        FlutterLogo(size: constraints.maxWidth * 0.4), // Logo
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'MineCheck',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+                const Spacer(),
+                Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: constraints.maxWidth * 0.1,
+                  ),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: _signIn,
+                      child: const Text('Ingresar con Microsoft'),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'features/autenticacion/presentacion/paginas/login_page.dart';
+
+void main() {
+  runApp(const MineCheckApp());
+}
+
+class MineCheckApp extends StatelessWidget {
+  const MineCheckApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'MineCheck',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
+      ),
+      home: const LoginPage(),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  msal_flutter: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- build responsive Microsoft Entra login screen with Flutter logo, title and sign-in button
- wire button to msal_flutter sign-in flow
- set login screen as app's initial page

## Testing
- `flutter test` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689298b3326c8331ba4b188fada03f96