### PR TITLE
feat: load client ID from env config

### DIFF
--- a/lib/core/config/environment_config.dart
+++ b/lib/core/config/environment_config.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+
+/// Provides access to compile-time environment variables.
+class EnvironmentConfig {
+  static String get clientId {
+    const clientId = String.fromEnvironment('CLIENT_ID');
+    if (clientId.isEmpty && kDebugMode) {
+      debugPrint('CLIENT_ID is not set');
+    }
+    return clientId;
+  }
+}

--- a/lib/features/autenticacion/presentacion/paginas/login_page.dart
+++ b/lib/features/autenticacion/presentacion/paginas/login_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:msal_flutter/msal_flutter.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/config/environment_config.dart';
 
 /// Pantalla de inicio de sesión basada en Microsoft Entra.
 class LoginPage extends StatefulWidget {
@@ -15,9 +16,11 @@ class _LoginPageState extends State<LoginPage> {
   @override
   void initState() {
     super.initState();
-    // TODO: Reemplazar con el clientId real de la aplicación.
+    // Inicializa la aplicación cliente pública utilizando el CLIENT_ID de la
+    // configuración de entorno. Si no se proporciona, se utilizará una cadena
+    // vacía para evitar errores en tiempo de ejecución.
     _pca = PublicClientApplication(
-      'REEMPLAZAR_CON_CLIENT_ID',
+      EnvironmentConfig.clientId,
       authority: 'https://login.microsoftonline.com/common',
     );
   }


### PR DESCRIPTION
## Summary
- read MSAL client ID from EnvironmentConfig with safe fallback
- add EnvironmentConfig utility for env vars

## Testing
- `dart format lib/core/config/environment_config.dart lib/features/autenticacion/presentacion/paginas/login_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68929aef537c83319cc8e44e2b5903ec