### PR TITLE
refactor: async pca initialization

### DIFF
--- a/lib/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source.dart
+++ b/lib/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source.dart
@@ -3,13 +3,18 @@ import 'package:veta_dorada_vinculacion_mobile/core/config/environment_config.da
 
 /// Remote data source that interacts with Azure AD through `msal_flutter`.
 class AzureAuthRemoteDataSource {
-  AzureAuthRemoteDataSource({dynamic pca})
-      : _pca = pca ??
-            PublicClientApplication(
-              EnvironmentConfig.clientId,
-              authority:
-                  'https://login.microsoftonline.com/${EnvironmentConfig.tenantId}',
-            );
+  AzureAuthRemoteDataSource._(this._pca);
+
+  static Future<AzureAuthRemoteDataSource> create({dynamic pca}) async {
+    final config = PublicClientApplicationConfiguration(
+      clientId: EnvironmentConfig.clientId,
+      authority:
+          'https://login.microsoftonline.com/${EnvironmentConfig.tenantId}',
+    );
+    final instance =
+        pca ?? await PublicClientApplication.createPublicClientApplication(config);
+    return AzureAuthRemoteDataSource._(instance);
+  }
 
   final dynamic _pca;
 

--- a/lib/features/autenticacion/presentacion/paginas/login_page.dart
+++ b/lib/features/autenticacion/presentacion/paginas/login_page.dart
@@ -16,14 +16,16 @@ class _LoginPageState extends State<LoginPage> {
   @override
   void initState() {
     super.initState();
-    // Inicializa la aplicación cliente pública utilizando el CLIENT_ID de la
-    // configuración de entorno. Si no se proporciona, se utilizará una cadena
-    // vacía para evitar errores en tiempo de ejecución.
-    _pca = PublicClientApplication(
-      EnvironmentConfig.clientId,
+    _initPca();
+  }
+
+  Future<void> _initPca() async {
+    final config = PublicClientApplicationConfiguration(
+      clientId: EnvironmentConfig.clientId,
       authority:
           'https://login.microsoftonline.com/${EnvironmentConfig.tenantId}',
     );
+    _pca = await PublicClientApplication.createPublicClientApplication(config);
   }
 
   Future<void> _signIn() async {

--- a/test/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source_test.dart
+++ b/test/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source_test.dart
@@ -25,9 +25,9 @@ void main() {
     late _FakePca fakePca;
     late AzureAuthRemoteDataSource dataSource;
 
-    setUp(() {
+    setUp(() async {
       fakePca = _FakePca();
-      dataSource = AzureAuthRemoteDataSource(pca: fakePca);
+      dataSource = await AzureAuthRemoteDataSource.create(pca: fakePca);
     });
 
     test('login returns token on success', () async {


### PR DESCRIPTION
## Summary
- initialize Azure Auth MSAL client using async factory
- async initialization for login page's MSAL client
- update tests for async AzureAuthRemoteDataSource construction

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892bba75ed88331941f32c955238a29