### PR TITLE
refactor: migrate MSAL config to v2 API

### DIFF
--- a/lib/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source.dart
+++ b/lib/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source.dart
@@ -6,13 +6,13 @@ class AzureAuthRemoteDataSource {
   AzureAuthRemoteDataSource._(this._pca);
 
   static Future<AzureAuthRemoteDataSource> create({dynamic pca}) async {
-    final config = MsalConfiguration(
+    final config = PublicClientApplicationConfiguration(
       clientId: EnvironmentConfig.clientId,
       authority:
           'https://login.microsoftonline.com/${EnvironmentConfig.tenantId}',
     );
-    final instance =
-        pca ?? await PublicClientApplication.createPublicClientApplication(config);
+    final instance = pca ??
+        await PublicClientApplication.createPublicClientApplication(config);
     return AzureAuthRemoteDataSource._(instance);
   }
 


### PR DESCRIPTION
## Summary
- switch to `PublicClientApplicationConfiguration`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892c753af5c833189a561f411b8d39c