### PR TITLE
refactor environment config

### DIFF
--- a/lib/core/config/environment_config.dart
+++ b/lib/core/config/environment_config.dart
@@ -1,28 +1,12 @@
-import 'package:flutter/foundation.dart';
-
 /// Provides access to compile-time environment variables.
 class EnvironmentConfig {
-  static const _clientIdKey = 'CLIENT_ID';
-  static const _tenantIdKey = 'TENANT_ID';
-  static const _defaultScopesKey = 'DEFAULT_SCOPES';
+  static const String clientId = String.fromEnvironment('CLIENT_ID');
+  static const String tenantId = String.fromEnvironment('TENANT_ID');
+  static const String _defaultScopes =
+      String.fromEnvironment('DEFAULT_SCOPES');
 
-  static String get clientId => _read(_clientIdKey);
-
-  /// Tenant identifier for Azure AD authentication.
-  static String get tenantId => _read(_tenantIdKey);
-
-  /// Default scopes requested during authentication.
-  static List<String> get defaultScopes =>
-      _read(_defaultScopesKey)
-          .split(RegExp(r'[ ,]+'))
-          .where((scope) => scope.isNotEmpty)
-          .toList();
-
-  static String _read(String key) {
-    final value = const String.fromEnvironment(key);
-    if (value.isEmpty && kDebugMode) {
-      debugPrint('$key is not set');
-    }
-    return value;
-  }
+  static List<String> get defaultScopes => _defaultScopes
+      .split(RegExp(r'[ ,]+'))
+      .where((scope) => scope.isNotEmpty)
+      .toList();
 }


### PR DESCRIPTION
## Summary
- read environment variables directly with `String.fromEnvironment`
- drop `_read` helper and unused keys

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892cf46af708331af4fe82f1fd9eb75