### PR TITLE
chore: replace msal_flutter with flutter_appauth

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -131,14 +131,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
-  msal_flutter:
+  flutter_appauth:
     dependency: "direct main"
     description:
-      name: msal_flutter
-      sha256: "5123bda74d513f44dd6489fe30835a138c40299bdf1e33a00df7007607c09258"
+      name: flutter_appauth
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "6.0.3"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  msal_flutter: ^2.0.1
+  flutter_appauth: ^6.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- remove msal_flutter dependency
- add flutter_appauth dependency at the latest stable version

## Testing
- `flutter pub get` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6892d777d7e083319f47e87aacd25392