### PR TITLE
refactor: switch to flutter_appauth

### DIFF
--- a/lib/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source.dart
+++ b/lib/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source.dart
@@ -1,41 +1,91 @@
-import 'package:msal_flutter/msal_flutter.dart';
+import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:veta_dorada_vinculacion_mobile/core/config/environment_config.dart';
 
-/// Remote data source that interacts with Azure AD through `msal_flutter`.
+/// Remote data source that interacts with Azure AD through `flutter_appauth`.
 class AzureAuthRemoteDataSource {
-  AzureAuthRemoteDataSource._(this._pca);
+  AzureAuthRemoteDataSource._(this._appAuth);
 
-  static Future<AzureAuthRemoteDataSource> create({dynamic pca}) async {
-    final instance =
-        pca ?? await PublicClientApplication.createPublicClientApplication(EnvironmentConfig.clientId,authority: 'https://login.microsoftonline.com/${EnvironmentConfig.tenantId}');
+  static AzureAuthRemoteDataSource create({FlutterAppAuth? appAuth}) {
+    final instance = appAuth ?? FlutterAppAuth();
     return AzureAuthRemoteDataSource._(instance);
   }
 
-  final dynamic _pca;
+  final FlutterAppAuth _appAuth;
+  String? _refreshToken;
+  String? _idToken;
 
   /// Initiates the interactive login flow and returns the access token.
   Future<String> login() async {
     try {
-      return await _pca.acquireTokenInteractive(
-        scopes: EnvironmentConfig.defaultScopes,
+      final result = await _appAuth.authorizeAndExchangeCode(
+        AuthorizationTokenRequest(
+          EnvironmentConfig.clientId,
+          EnvironmentConfig.redirectUri,
+          scopes: EnvironmentConfig.defaultScopes,
+          issuer: EnvironmentConfig.issuer,
+          discoveryUrl: EnvironmentConfig.discoveryUrl.isNotEmpty
+              ? EnvironmentConfig.discoveryUrl
+              : null,
+        ),
       );
-    } catch (e) {
+
+      _refreshToken = result.refreshToken;
+      _idToken = result.idToken;
+
+      final accessToken = result.accessToken;
+      if (accessToken == null) {
+        throw AzureAuthException('Failed to login: no access token');
+      }
+      return accessToken;
+    } on Exception catch (e) {
       throw AzureAuthException('Failed to login: $e');
     }
   }
 
   /// Clears the current session from the client application.
   Future<void> logout() async {
-    await _pca.logout();
+    try {
+      await _appAuth.endSession(
+        EndSessionRequest(
+          idTokenHint: _idToken,
+          postLogoutRedirectUrl: EnvironmentConfig.endSessionRedirectUri,
+          issuer: EnvironmentConfig.issuer,
+          discoveryUrl: EnvironmentConfig.discoveryUrl.isNotEmpty
+              ? EnvironmentConfig.discoveryUrl
+              : null,
+        ),
+      );
+      _refreshToken = null;
+      _idToken = null;
+    } on Exception catch (e) {
+      throw AzureAuthException('Failed to logout: $e');
+    }
   }
 
-  /// Attempts to silently acquire a new access token using cached credentials.
+  /// Attempts to silently acquire a new access token using the refresh token.
   Future<String> refreshToken() async {
     try {
-      return await _pca.acquireTokenSilent(
-        scopes: EnvironmentConfig.defaultScopes,
+      final result = await _appAuth.token(
+        TokenRequest(
+          EnvironmentConfig.clientId,
+          EnvironmentConfig.redirectUri,
+          refreshToken: _refreshToken,
+          scopes: EnvironmentConfig.defaultScopes,
+          issuer: EnvironmentConfig.issuer,
+          discoveryUrl: EnvironmentConfig.discoveryUrl.isNotEmpty
+              ? EnvironmentConfig.discoveryUrl
+              : null,
+        ),
       );
-    } catch (e) {
+
+      _refreshToken = result.refreshToken ?? _refreshToken;
+
+      final accessToken = result.accessToken;
+      if (accessToken == null) {
+        throw AzureAuthException('Failed to refresh token: no access token');
+      }
+      return accessToken;
+    } on Exception catch (e) {
       throw AzureAuthException('Failed to refresh token: $e');
     }
   }


### PR DESCRIPTION
## Summary
- refactor Azure auth data source to use flutter_appauth instead of msal
- implement login, logout and refresh via flutter_appauth with EnvironmentConfig

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892dff2eb088331b7d234cbb107658f