### PR TITLE
Configure Android redirect scheme placeholder

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -29,6 +29,11 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        val redirectUri: String? = System.getenv("REDIRECT_URI")
+        val redirectScheme = redirectUri?.substringBefore("://") ?: ""
+        manifestPlaceholders += mapOf(
+            "appAuthRedirectScheme" to redirectScheme
+        )
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- derive appAuth redirect scheme from REDIRECT_URI and expose via manifest placeholder

## Testing
- `flutter clean` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894d7db23c08331a30a8049c080ea32