### PR TITLE
feat: add API base url config and auth HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ AD authentication. Provide them when running or building the app using
 | `CLIENT_ID` | Azure application (client) identifier. |
 | `TENANT_ID` | Azure AD tenant identifier. |
 | `DEFAULT_SCOPES` | Space- or comma-separated list of scopes, e.g. `User.Read`. |
+| `API_BASE_URL` | Base URL for backend API requests. |
 
 Example:
 
 ```bash
-flutter run \
-  --dart-define=CLIENT_ID=your_client_id \
-  --dart-define=TENANT_ID=your_tenant_id \
-  --dart-define=DEFAULT_SCOPES="User.Read"
+  flutter run \
+    --dart-define=CLIENT_ID=your_client_id \
+    --dart-define=TENANT_ID=your_tenant_id \
+    --dart-define=DEFAULT_SCOPES="User.Read" \
+    --dart-define=API_BASE_URL=http://localhost:44377
 ```
 
 ## Run on Android Emulator
@@ -45,10 +47,11 @@ Launch the app on a specific emulator, supplying the same compile-time
 environment variables:
 
 ```bash
-flutter run -d emulator-5554 \
-  --dart-define=CLIENT_ID=your_client_id \
-  --dart-define=TENANT_ID=your_tenant_id \
-  --dart-define=DEFAULT_SCOPES="User.Read"
+  flutter run -d emulator-5554 \
+    --dart-define=CLIENT_ID=your_client_id \
+    --dart-define=TENANT_ID=your_tenant_id \
+    --dart-define=DEFAULT_SCOPES="User.Read" \
+    --dart-define=API_BASE_URL=http://localhost:44377
 ```
 
 These `--dart-define` parameters are required when running on the emulator as

--- a/lib/core/config/environment_config.dart
+++ b/lib/core/config/environment_config.dart
@@ -25,6 +25,9 @@ class EnvironmentConfig {
   static const String endSessionRedirectUri =
       String.fromEnvironment('END_SESSION_REDIRECT_URI');
 
+  /// Base URL for backend API requests.
+  static const String apiBaseUrl = String.fromEnvironment('API_BASE_URL');
+
   /// Comma or space separated list of scopes requested during authentication.
   static const String _defaultScopes =
       String.fromEnvironment('DEFAULT_SCOPES');

--- a/lib/core/red/cliente_http.dart
+++ b/lib/core/red/cliente_http.dart
@@ -1,0 +1,31 @@
+import 'package:http/http.dart' as http;
+
+/// A simple HTTP client that injects an Azure AD bearer token into every
+/// request. It wraps an underlying [http.Client] and exposes the standard
+/// methods such as [get], [post], etc.
+class ClienteHttp extends http.BaseClient {
+  /// Creates an instance of [ClienteHttp] using the provided [token].
+  ///
+  /// An optional [inner] client can be supplied for testing purposes. If none
+  /// is provided, a default [http.Client] is used.
+  ClienteHttp({required this.token, http.Client? inner})
+      : _inner = inner ?? http.Client();
+
+  /// Azure AD bearer token used for authentication.
+  final String token;
+
+  /// Underlying HTTP client that actually sends the requests.
+  final http.Client _inner;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    request.headers['Authorization'] = 'Bearer $token';
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    _inner.close();
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   flutter_appauth: ^6.0.3
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add API base url to environment config
- implement HTTP client wrapper injecting Azure token
- document API_BASE_URL dart define and add http package

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951d23f38083319dded7993a3cedfb