### PR TITLE
feat(perfil): add usuario model and remote data source

### DIFF
--- a/lib/features/perfil/datos/fuentes_datos/perfil_remote_data_source.dart
+++ b/lib/features/perfil/datos/fuentes_datos/perfil_remote_data_source.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:veta_dorada_vinculacion_mobile/core/config/environment_config.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
+
+import '../modelos/usuario.dart';
+
+/// Fuente de datos remota que obtiene el perfil del usuario desde la API.
+class PerfilRemoteDataSource {
+  PerfilRemoteDataSource(this._client);
+
+  final ClienteHttp _client;
+
+  /// Realiza una solicitud GET a `/api/perfil` y devuelve un [Usuario].
+  Future<Usuario> obtenerPerfil() async {
+    final uri = Uri.parse('${EnvironmentConfig.apiBaseUrl}/api/perfil');
+    final response = await _client.get(uri);
+
+    if (response.statusCode != 200) {
+      throw PerfilRemoteException(
+        'Error al obtener el perfil: ${response.statusCode}',
+      );
+    }
+
+    final Map<String, dynamic> data =
+        jsonDecode(response.body) as Map<String, dynamic>;
+    return Usuario.fromJson(data);
+  }
+}
+
+/// Excepción que se lanza cuando ocurre un error al obtener el perfil.
+class PerfilRemoteException implements Exception {
+  PerfilRemoteException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'PerfilRemoteException: $message';
+}
+

--- a/lib/features/perfil/datos/modelos/usuario.dart
+++ b/lib/features/perfil/datos/modelos/usuario.dart
@@ -1,0 +1,34 @@
+/// Modelo que representa la información básica de un usuario.
+class Usuario {
+  const Usuario({
+    required this.id,
+    required this.nombre,
+    required this.correo,
+  });
+
+  /// Identificador único del usuario.
+  final String id;
+
+  /// Nombre completo del usuario.
+  final String nombre;
+
+  /// Correo electrónico del usuario.
+  final String correo;
+
+  /// Crea una instancia de [Usuario] a partir de un mapa JSON.
+  factory Usuario.fromJson(Map<String, dynamic> json) {
+    return Usuario(
+      id: json['id'] as String,
+      nombre: json['nombre'] as String,
+      correo: json['correo'] as String,
+    );
+  }
+
+  /// Convierte el [Usuario] a un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'nombre': nombre,
+        'correo': correo,
+      };
+}
+


### PR DESCRIPTION
## Summary
- add `Usuario` model for profile feature
- implement `PerfilRemoteDataSource` to fetch profile from API using `ClienteHttp`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895201285208331bc3c43eac6cf39d2