### PR TITLE
Add reusable scaffold with user toolbar and side navigation

### DIFF
--- a/lib/core/widgets/protected_scaffold.dart
+++ b/lib/core/widgets/protected_scaffold.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
+import 'side_nav.dart';
+import 'user_toolbar.dart';
+
+/// `Scaffold` reutilizable que integra el `SideNav` y el `UserToolbar` para
+/// las rutas que requieren autenticación.
+class ProtectedScaffold extends StatefulWidget {
+  const ProtectedScaffold({
+    super.key,
+    required this.body,
+    required this.usuario,
+    required this.token,
+    this.puesto,
+    required this.onNavigate,
+  });
+
+  /// Contenido principal de la página.
+  final Widget body;
+
+  /// Usuario autenticado.
+  final Usuario usuario;
+
+  /// Token para obtener la foto del usuario.
+  final String token;
+
+  /// Puesto del usuario.
+  final String? puesto;
+
+  /// Callback de navegación utilizado por el `SideNav`.
+  final void Function(String ruta) onNavigate;
+
+  @override
+  State<ProtectedScaffold> createState() => _ProtectedScaffoldState();
+}
+
+class _ProtectedScaffoldState extends State<ProtectedScaffold> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: _scaffoldKey,
+      drawer: SideNav(
+        usuario: widget.usuario,
+        onNavigate: widget.onNavigate,
+      ),
+      appBar: UserToolbar(
+        usuario: widget.usuario,
+        puesto: widget.puesto,
+        token: widget.token,
+        onMenuPressed: () => _scaffoldKey.currentState?.openDrawer(),
+      ),
+      body: widget.body,
+    );
+  }
+}

--- a/lib/core/widgets/side_nav.dart
+++ b/lib/core/widgets/side_nav.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
+
+/// Widget que representa el menú lateral de navegación.
+///
+/// Muestra la información básica del [usuario] y permite navegar a otras
+/// secciones utilizando el callback [onNavigate].
+class SideNav extends StatelessWidget {
+  const SideNav({
+    super.key,
+    required this.usuario,
+    required this.onNavigate,
+  });
+
+  /// Información del usuario autenticado.
+  final Usuario usuario;
+
+  /// Callback que se ejecuta al seleccionar una opción de navegación.
+  /// Se pasa la ruta seleccionada como parámetro.
+  final void Function(String ruta) onNavigate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: [
+          UserAccountsDrawerHeader(
+            accountName: Text(usuario.nombre),
+            accountEmail: Text(usuario.correo),
+            currentAccountPicture: const CircleAvatar(
+              child: Icon(Icons.person),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.home),
+            title: const Text('Inicio'),
+            onTap: () => onNavigate('/'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/user_toolbar.dart
+++ b/lib/core/widgets/user_toolbar.dart
@@ -1,0 +1,86 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
+
+/// Barra de herramientas que muestra la información del usuario y controles
+/// comunes para las rutas protegidas.
+class UserToolbar extends StatelessWidget implements PreferredSizeWidget {
+  const UserToolbar({
+    super.key,
+    required this.usuario,
+    required this.token,
+    this.puesto,
+    this.onMenuPressed,
+  });
+
+  /// Información del usuario autenticado.
+  final Usuario usuario;
+
+  /// Token de acceso utilizado para obtener la foto desde Microsoft Graph.
+  final String token;
+
+  /// Puesto o cargo del usuario.
+  final String? puesto;
+
+  /// Callback que se ejecuta al presionar el botón de menú para abrir el
+  /// [Drawer].
+  final VoidCallback? onMenuPressed;
+
+  /// Obtiene la imagen de perfil del usuario desde Microsoft Graph.
+  Future<Uint8List?> _fetchPhoto() async {
+    final uri = Uri.parse('https://graph.microsoft.com/v1.0/me/photo/\$value');
+    final response = await http.get(
+      uri,
+      headers: {'Authorization': 'Bearer ' + token},
+    );
+    if (response.statusCode == 200) {
+      return response.bodyBytes;
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.menu),
+        onPressed: onMenuPressed,
+      ),
+      title: Row(
+        children: [
+          FutureBuilder<Uint8List?>(
+            future: _fetchPhoto(),
+            builder: (context, snapshot) {
+              final bytes = snapshot.data;
+              return CircleAvatar(
+                backgroundImage: bytes != null ? MemoryImage(bytes) : null,
+                child: bytes == null ? const Icon(Icons.person) : null,
+              );
+            },
+          ),
+          const SizedBox(width: 8),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(usuario.nombre, style: const TextStyle(fontSize: 16)),
+              if (puesto != null)
+                Text(puesto!, style: const TextStyle(fontSize: 12)),
+            ],
+          ),
+        ],
+      ),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.more_vert),
+          onPressed: () {},
+        ),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
+++ b/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
@@ -1,19 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/widgets/protected_scaffold.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
 
 /// Página principal de ejemplo para el flujo autenticado.
 class VisitasTabsPage extends StatelessWidget {
-  const VisitasTabsPage({super.key});
+  const VisitasTabsPage({
+    super.key,
+    required this.usuario,
+    required this.token,
+    this.puesto,
+  });
+
+  /// Usuario autenticado.
+  final Usuario usuario;
+
+  /// Token para obtener la foto del usuario.
+  final String token;
+
+  /// Puesto del usuario.
+  final String? puesto;
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('MineCheck'),
-      ),
+    return ProtectedScaffold(
+      usuario: usuario,
+      token: token,
+      puesto: puesto,
+      onNavigate: (ruta) => Navigator.of(context).pushNamed(ruta),
       body: const Center(
         child: Text('Bienvenido al flujo principal'),
       ),
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- create SideNav drawer that accepts a Usuario and navigation callback
- add UserToolbar to show user name, job title and photo fetched from Microsoft Graph
- provide ProtectedScaffold integrating toolbar and side nav and update visitas tabs page to use it

## Testing
- `dart format lib/core/widgets/side_nav.dart lib/core/widgets/user_toolbar.dart lib/core/widgets/protected_scaffold.dart lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689523f21fa88331b6cdb88b586ebb2e