### PR TITLE
feat(visitas): add domain entities

### DIFF
--- a/lib/features/visitas/dominio/entidades/derecho_minero.dart
+++ b/lib/features/visitas/dominio/entidades/derecho_minero.dart
@@ -1,0 +1,32 @@
+/// Derecho minero asociado a la visita.
+class DerechoMinero {
+  /// Identificador único del derecho minero.
+  final String id;
+
+  /// Código oficial del derecho minero.
+  final String codigo;
+
+  /// Nombre del derecho minero.
+  final String nombre;
+
+  /// Crea una instancia de [DerechoMinero].
+  const DerechoMinero({
+    required this.id,
+    required this.codigo,
+    required this.nombre,
+  });
+
+  /// Crea un [DerechoMinero] a partir de un mapa JSON.
+  factory DerechoMinero.fromJson(Map<String, dynamic> json) => DerechoMinero(
+        id: json['id'] as String,
+        codigo: json['codigo'] as String,
+        nombre: json['nombre'] as String,
+      );
+
+  /// Convierte el [DerechoMinero] en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'codigo': codigo,
+        'nombre': nombre,
+      };
+}

--- a/lib/features/visitas/dominio/entidades/general.dart
+++ b/lib/features/visitas/dominio/entidades/general.dart
@@ -1,0 +1,49 @@
+/// Información general de una visita.
+class General {
+  /// Estado para una visita programada.
+  static const String ESTADO_VISITA_PROGRAMADA = 'PROGRAMADA';
+
+  /// Estado para una visita en proceso.
+  static const String ESTADO_VISITA_EN_PROCESO = 'EN_PROCESO';
+
+  /// Estado para una visita finalizada.
+  static const String ESTADO_VISITA_FINALIZADA = 'FINALIZADA';
+
+  /// Estado actual de la visita.
+  final String estado;
+
+  /// Fecha programada de la visita.
+  final DateTime fechaProgramada;
+
+  /// Fecha real de ejecución de la visita.
+  final DateTime? fechaEjecucion;
+
+  /// Observaciones adicionales de la visita.
+  final String? observaciones;
+
+  /// Crea una instancia de [General].
+  const General({
+    required this.estado,
+    required this.fechaProgramada,
+    this.fechaEjecucion,
+    this.observaciones,
+  });
+
+  /// Crea [General] a partir de un mapa JSON.
+  factory General.fromJson(Map<String, dynamic> json) => General(
+        estado: json['estado'] as String,
+        fechaProgramada: DateTime.parse(json['fechaProgramada'] as String),
+        fechaEjecucion: json['fechaEjecucion'] != null
+            ? DateTime.parse(json['fechaEjecucion'] as String)
+            : null,
+        observaciones: json['observaciones'] as String?,
+      );
+
+  /// Convierte la información general en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'estado': estado,
+        'fechaProgramada': fechaProgramada.toIso8601String(),
+        'fechaEjecucion': fechaEjecucion?.toIso8601String(),
+        'observaciones': observaciones,
+      };
+}

--- a/lib/features/visitas/dominio/entidades/proveedor.dart
+++ b/lib/features/visitas/dominio/entidades/proveedor.dart
@@ -1,0 +1,23 @@
+/// Representa al proveedor responsable de una visita.
+class Proveedor {
+  /// Identificador único del proveedor.
+  final String id;
+
+  /// Nombre o razón social del proveedor.
+  final String nombre;
+
+  /// Crea una instancia de [Proveedor].
+  const Proveedor({required this.id, required this.nombre});
+
+  /// Crea un [Proveedor] a partir de un mapa JSON.
+  factory Proveedor.fromJson(Map<String, dynamic> json) => Proveedor(
+        id: json['id'] as String,
+        nombre: json['nombre'] as String,
+      );
+
+  /// Convierte el [Proveedor] en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'nombre': nombre,
+      };
+}

--- a/lib/features/visitas/dominio/entidades/tipo_visita.dart
+++ b/lib/features/visitas/dominio/entidades/tipo_visita.dart
@@ -1,0 +1,23 @@
+/// Describe el tipo de visita a realizar.
+class TipoVisita {
+  /// Identificador único del tipo de visita.
+  final String id;
+
+  /// Descripción del tipo de visita.
+  final String descripcion;
+
+  /// Crea una instancia de [TipoVisita].
+  const TipoVisita({required this.id, required this.descripcion});
+
+  /// Crea un [TipoVisita] a partir de un mapa JSON.
+  factory TipoVisita.fromJson(Map<String, dynamic> json) => TipoVisita(
+        id: json['id'] as String,
+        descripcion: json['descripcion'] as String,
+      );
+
+  /// Convierte el [TipoVisita] en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'descripcion': descripcion,
+      };
+}

--- a/lib/features/visitas/dominio/entidades/visita.dart
+++ b/lib/features/visitas/dominio/entidades/visita.dart
@@ -1,0 +1,52 @@
+import 'derecho_minero.dart';
+import 'general.dart';
+import 'proveedor.dart';
+import 'tipo_visita.dart';
+
+/// Representa una visita programada a un derecho minero.
+class Visita {
+  /// Identificador único de la visita.
+  final String id;
+
+  /// Información general de la visita.
+  final General general;
+
+  /// Proveedor encargado de realizar la visita.
+  final Proveedor proveedor;
+
+  /// Tipo de visita que se realizará.
+  final TipoVisita tipoVisita;
+
+  /// Derecho minero asociado a la visita.
+  final DerechoMinero derechoMinero;
+
+  /// Crea una instancia de [Visita].
+  const Visita({
+    required this.id,
+    required this.general,
+    required this.proveedor,
+    required this.tipoVisita,
+    required this.derechoMinero,
+  });
+
+  /// Crea una [Visita] a partir de un mapa JSON.
+  factory Visita.fromJson(Map<String, dynamic> json) => Visita(
+        id: json['id'] as String,
+        general: General.fromJson(json['general'] as Map<String, dynamic>),
+        proveedor:
+            Proveedor.fromJson(json['proveedor'] as Map<String, dynamic>),
+        tipoVisita:
+            TipoVisita.fromJson(json['tipoVisita'] as Map<String, dynamic>),
+        derechoMinero: DerechoMinero.fromJson(
+            json['derechoMinero'] as Map<String, dynamic>),
+      );
+
+  /// Convierte la visita en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'general': general.toJson(),
+        'proveedor': proveedor.toJson(),
+        'tipoVisita': tipoVisita.toJson(),
+        'derechoMinero': derechoMinero.toJson(),
+      };
+}


### PR DESCRIPTION
## Summary
- add visit domain entities with json serialization
- document entity fields and constants

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952f7137188331a5b8b3b26e015e0b