### PR TITLE
Implement visits repository with local cache fallback

### DIFF
--- a/lib/features/visitas/datos/repositorios/visits_repository_impl.dart
+++ b/lib/features/visitas/datos/repositorios/visits_repository_impl.dart
@@ -1,0 +1,36 @@
+import '../../dominio/entidades/visita.dart';
+import '../../dominio/repositorios/visits_repository.dart';
+import '../fuentes_datos/visits_local_data_source.dart';
+import '../fuentes_datos/visits_remote_data_source.dart';
+
+/// Implementación de [VisitsRepository] que combina fuentes remotas y locales.
+class VisitsRepositoryImpl implements VisitsRepository {
+  VisitsRepositoryImpl(this._remoteDataSource, this._localDataSource);
+
+  final VisitsRemoteDataSource _remoteDataSource;
+  final VisitsLocalDataSource _localDataSource;
+
+  @override
+  Future<({Map<String, List<Visita>> visitas, String? advertencia})>
+      obtenerVisitasPorGeologo(String id) async {
+    try {
+      final remotas = await _remoteDataSource.obtenerVisitas(id);
+      await _localDataSource.insertVisits(remotas);
+      final Map<String, List<Visita>> agrupadas = {};
+      for (final visita in remotas) {
+        agrupadas.putIfAbsent(visita.general.estado, () => []).add(visita);
+      }
+      return (visitas: agrupadas, advertencia: null);
+    } catch (e) {
+      final locales = await _localDataSource.getVisitsGroupedByState();
+      final Map<String, List<Visita>> agrupadas = {};
+      locales.forEach((estado, visitas) {
+        agrupadas[estado] = visitas.cast<Visita>();
+      });
+      return (
+        visitas: agrupadas,
+        advertencia: 'No se pudieron sincronizar las visitas: $e',
+      );
+    }
+  }
+}

--- a/lib/features/visitas/dominio/repositorios/visits_repository.dart
+++ b/lib/features/visitas/dominio/repositorios/visits_repository.dart
@@ -1,0 +1,11 @@
+import '../entidades/visita.dart';
+
+/// Contrato para el acceso a visitas.
+abstract class VisitsRepository {
+  /// Obtiene las visitas del geólogo identificado por [id] agrupadas por estado.
+  ///
+  /// Retorna un registro con las listas y un [advertencia] cuando la
+  /// sincronización remota falla y se usan datos locales.
+  Future<({Map<String, List<Visita>> visitas, String? advertencia})>
+      obtenerVisitasPorGeologo(String id);
+}


### PR DESCRIPTION
## Summary
- define VisitsRepository interface exposing grouped fetch and warning flag
- implement VisitsRepositoryImpl using remote synchronization with local persistence and fallback

## Testing
- `dart format lib/features/visitas/dominio/repositorios/visits_repository.dart lib/features/visitas/datos/repositorios/visits_repository_impl.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68954f90990c833198b05ee71beeca49