### PR TITLE
feat: implement visits bloc

### DIFF
--- a/lib/features/visitas/presentacion/bloc/visitas_bloc.dart
+++ b/lib/features/visitas/presentacion/bloc/visitas_bloc.dart
@@ -1,0 +1,53 @@
+import 'package:bloc/bloc.dart';
+
+import '../../datos/fuentes_datos/visits_local_data_source.dart'
+    show VisitsLocalException;
+import '../../dominio/entidades/general.dart';
+import '../../dominio/entidades/visita.dart';
+import '../../dominio/repositorios/visits_repository.dart';
+
+part 'visitas_event.dart';
+part 'visitas_state.dart';
+
+class VisitasBloc extends Bloc<VisitasEvent, VisitasState> {
+  VisitasBloc(this._repository) : super(VisitasCargando()) {
+    on<CargarVisitas>(_onCargarVisitas);
+    on<SincronizarVisitas>(_onSincronizarVisitas);
+  }
+
+  final VisitsRepository _repository;
+
+  Future<void> _onCargarVisitas(
+    CargarVisitas event,
+    Emitter<VisitasState> emit,
+  ) async {
+    emit(VisitasCargando());
+    try {
+      final resultado =
+          await _repository.obtenerVisitasPorGeologo(event.idGeologo);
+      final programadas =
+          resultado.visitas[General.ESTADO_VISITA_PROGRAMADA] ?? [];
+      final borrador =
+          resultado.visitas[General.ESTADO_VISITA_EN_PROCESO] ?? [];
+      final completadas =
+          resultado.visitas[General.ESTADO_VISITA_FINALIZADA] ?? [];
+      emit(VisitasCargadas(
+        programadas: programadas,
+        borrador: borrador,
+        completadas: completadas,
+        advertencia: resultado.advertencia,
+      ));
+    } on VisitsLocalException catch (e) {
+      emit(VisitasError(e.message));
+    } catch (e) {
+      emit(VisitasError(e.toString()));
+    }
+  }
+
+  Future<void> _onSincronizarVisitas(
+    SincronizarVisitas event,
+    Emitter<VisitasState> emit,
+  ) async {
+    await _onCargarVisitas(CargarVisitas(event.idGeologo), emit);
+  }
+}

--- a/lib/features/visitas/presentacion/bloc/visitas_event.dart
+++ b/lib/features/visitas/presentacion/bloc/visitas_event.dart
@@ -1,0 +1,13 @@
+part of 'visitas_bloc.dart';
+
+abstract class VisitasEvent {}
+
+class CargarVisitas extends VisitasEvent {
+  CargarVisitas(this.idGeologo);
+  final String idGeologo;
+}
+
+class SincronizarVisitas extends VisitasEvent {
+  SincronizarVisitas(this.idGeologo);
+  final String idGeologo;
+}

--- a/lib/features/visitas/presentacion/bloc/visitas_state.dart
+++ b/lib/features/visitas/presentacion/bloc/visitas_state.dart
@@ -1,0 +1,24 @@
+part of 'visitas_bloc.dart';
+
+abstract class VisitasState {}
+
+class VisitasCargando extends VisitasState {}
+
+class VisitasCargadas extends VisitasState {
+  VisitasCargadas({
+    required this.programadas,
+    required this.borrador,
+    required this.completadas,
+    this.advertencia,
+  });
+
+  final List<Visita> programadas;
+  final List<Visita> borrador;
+  final List<Visita> completadas;
+  final String? advertencia;
+}
+
+class VisitasError extends VisitasState {
+  VisitasError(this.mensaje);
+  final String mensaje;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   go_router: ^13.2.0
   sqflite: ^2.3.0+1
   path: ^1.9.0
+  bloc: ^8.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add bloc dependency
- implement events, states and bloc for visits

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955141d0f083319098c78f9886b98e