### PR TITLE
Add visits tab view with custom tabs and card

### DIFF
--- a/lib/features/visitas/presentacion/componentes/pestana_personalizada.dart
+++ b/lib/features/visitas/presentacion/componentes/pestana_personalizada.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+/// Pestaña con estilo personalizado utilizada en el [TabBar] de visitas.
+class PestanaPersonalizada extends StatelessWidget {
+  const PestanaPersonalizada({super.key, required this.titulo});
+
+  /// Texto que se muestra en la pestaña.
+  final String titulo;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tab(
+      child: Text(
+        titulo,
+        style: const TextStyle(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/visitas/presentacion/componentes/visit_card.dart
+++ b/lib/features/visitas/presentacion/componentes/visit_card.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../../dominio/entidades/visita.dart';
+
+/// Tarjeta que muestra la información principal de una [Visita].
+class VisitCard extends StatelessWidget {
+  const VisitCard({
+    super.key,
+    required this.visita,
+    this.acopiador = '-',
+  });
+
+  /// Visita que se va a mostrar.
+  final Visita visita;
+
+  /// Nombre del acopiador asignado a la visita.
+  final String acopiador;
+
+  @override
+  Widget build(BuildContext context) {
+    final fecha = visita.general.fechaProgramada;
+    final fechaStr =
+        '${fecha.day.toString().padLeft(2, '0')}/${fecha.month.toString().padLeft(2, '0')}/${fecha.year}';
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              visita.tipoVisita.descripcion,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text('Código: ${visita.derechoMinero.codigo}'),
+            Text('Proveedor: ${visita.proveedor.nombre}'),
+            Text('Derecho minero: ${visita.derechoMinero.nombre}'),
+            Text('Acopiador: $acopiador'),
+            Text('Fecha: $fechaStr'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
+++ b/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
@@ -1,35 +1,111 @@
 import 'package:flutter/material.dart';
-import 'package:veta_dorada_vinculacion_mobile/core/widgets/protected_scaffold.dart';
-import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
 
-/// Página principal de ejemplo para el flujo autenticado.
-class VisitasTabsPage extends StatelessWidget {
-  const VisitasTabsPage({
-    super.key,
-    required this.usuario,
-    required this.token,
-    this.puesto,
-  });
+import '../../../core/auth/auth_provider.dart';
+import '../../../core/red/cliente_http.dart';
+import '../../../core/servicios/servicio_bd_local.dart';
+import '../../datos/fuentes_datos/visits_local_data_source.dart';
+import '../../datos/fuentes_datos/visits_remote_data_source.dart';
+import '../../datos/repositorios/visits_repository_impl.dart';
+import '../../dominio/entidades/visita.dart';
+import '../bloc/visitas_bloc.dart';
+import '../componentes/pestana_personalizada.dart';
+import '../componentes/visit_card.dart';
 
-  /// Usuario autenticado.
-  final Usuario usuario;
+/// Página que muestra las visitas organizadas en pestañas.
+class VisitasTabsPage extends StatefulWidget {
+  const VisitasTabsPage({super.key});
 
-  /// Token para obtener la foto del usuario.
-  final String token;
+  @override
+  State<VisitasTabsPage> createState() => _VisitasTabsPageState();
+}
 
-  /// Puesto del usuario.
-  final String? puesto;
+class _VisitasTabsPageState extends State<VisitasTabsPage> {
+  late VisitasBloc _bloc;
+  bool _inicializado = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_inicializado) return;
+    final auth = AuthProvider.of(context);
+    final remoto = VisitsRemoteDataSource(ClienteHttp(token: auth.token!));
+    final local = VisitsLocalDataSource(ServicioBdLocal());
+    final repo = VisitsRepositoryImpl(remoto, local);
+    _bloc = VisitasBloc(repo)..add(CargarVisitas(auth.usuario!.id));
+    _bloc.stream.listen((state) {
+      if (state is VisitasCargadas && state.advertencia != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(content: Text(state.advertencia!)));
+        });
+      }
+    });
+    _inicializado = true;
+  }
+
+  @override
+  void dispose() {
+    _bloc.close();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return ProtectedScaffold(
-      usuario: usuario,
-      token: token,
-      puesto: puesto,
-      onNavigate: (ruta) => Navigator.of(context).pushNamed(ruta),
-      body: const Center(
-        child: Text('Bienvenido al flujo principal'),
+    return DefaultTabController(
+      length: 3,
+      child: Column(
+        children: [
+          const TabBar(
+            indicatorColor: Colors.blue,
+            labelColor: Colors.blue,
+            tabs: [
+              PestanaPersonalizada(titulo: 'Programadas'),
+              PestanaPersonalizada(titulo: 'Borrador'),
+              PestanaPersonalizada(titulo: 'Completadas'),
+            ],
+          ),
+          Expanded(
+            child: StreamBuilder<VisitasState>(
+              stream: _bloc.stream,
+              initialData: _bloc.state,
+              builder: (context, snapshot) {
+                final state = snapshot.data;
+                if (state is VisitasCargando) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                if (state is VisitasCargadas) {
+                  return TabBarView(
+                    children: [
+                      _buildList(state.programadas),
+                      _buildList(state.borrador),
+                      _buildList(state.completadas),
+                    ],
+                  );
+                }
+                if (state is VisitasError) {
+                  return Center(child: Text(state.mensaje));
+                }
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ],
       ),
     );
   }
+
+  Widget _buildList(List<Visita> visitas) {
+    if (visitas.isEmpty) {
+      return const Center(child: Text('No hay visitas'));
+    }
+    return ListView.builder(
+      itemCount: visitas.length,
+      itemBuilder: (context, index) {
+        final visita = visitas[index];
+        return VisitCard(visita: visita);
+      },
+    );
+  }
 }
+


### PR DESCRIPTION
## Summary
- Add `PestanaPersonalizada` for styled visit tabs
- Implement `VisitCard` to show visit details
- Replace placeholder in `VisitasTabsPage` with tab controller and BLoC-driven lists

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955a532500833182ae7053f3436faf