### PR TITLE
Add visitas route constant and mapping

### DIFF
--- a/lib/core/constantes/rutas.dart
+++ b/lib/core/constantes/rutas.dart
@@ -1,0 +1,4 @@
+/// Constantes que definen las rutas de navegación de la aplicación.
+
+/// Ruta para la sección de visitas.
+const String rutaVisitas = '/visitas';

--- a/lib/rutas.dart
+++ b/lib/rutas.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import 'core/constantes/rutas.dart';
+import 'core/widgets/protected_scaffold.dart';
+import 'features/perfil/datos/modelos/usuario.dart';
+import 'features/visitas/presentacion/paginas/visitas_tabs_page.dart';
+
+/// Tipo de constructor para las rutas que requieren parámetros adicionales.
+typedef RutaBuilder = Widget Function(
+    BuildContext context, Usuario usuario, String token);
+
+/// Mapa de rutas de la aplicación.
+final Map<String, RutaBuilder> rutas = {
+  rutaVisitas: (context, usuario, token) => ProtectedScaffold(
+        body: const VisitasTabsPage(),
+        usuario: usuario,
+        token: token,
+        onNavigate: (ruta) => Navigator.of(context).pushNamed(ruta),
+      ),
+};


### PR DESCRIPTION
## Summary
- define `rutaVisitas` constant for visits section
- map `rutaVisitas` to `VisitasTabsPage` using `ProtectedScaffold`

## Testing
- `dart format lib/core/constantes/rutas.dart lib/rutas.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955d8f5f6c8331a6bd6c7099761382