### PR TITLE
Refresh access token on profile load failure

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'core/auth/auth_notifier.dart';
 import 'core/auth/auth_provider.dart';
 import 'core/red/cliente_http.dart';
+import 'features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source.dart';
 import 'features/perfil/datos/fuentes_datos/perfil_remote_data_source.dart';
 import 'router/app_router.dart';
 
@@ -17,14 +18,33 @@ Future<void> main() async {
 Future<void> _initAuth(AuthNotifier authNotifier) async {
   const storage = FlutterSecureStorage();
   final token = await storage.read(key: 'accessToken');
+  final refreshToken = await storage.read(key: 'refreshToken');
   if (token == null) return;
-  final client = ClienteHttp(token: token);
-  final perfilDataSource = PerfilRemoteDataSource(client);
+  var client = ClienteHttp(token: token);
+  var perfilDataSource = PerfilRemoteDataSource(client);
   try {
     final usuario = await perfilDataSource.obtenerPerfil();
     authNotifier.setAuthData(usuario: usuario, token: token);
   } catch (_) {
-    // Ignorar errores de carga inicial.
+    if (refreshToken == null) {
+      await storage.delete(key: 'accessToken');
+      await storage.delete(key: 'refreshToken');
+      authNotifier.clear();
+      return;
+    }
+    final authRemoteDataSource =
+        AzureAuthRemoteDataSource.create(secureStorage: storage);
+    try {
+      final newToken = await authRemoteDataSource.refreshToken();
+      client = ClienteHttp(token: newToken);
+      perfilDataSource = PerfilRemoteDataSource(client);
+      final usuario = await perfilDataSource.obtenerPerfil();
+      authNotifier.setAuthData(usuario: usuario, token: newToken);
+    } catch (_) {
+      await storage.delete(key: 'accessToken');
+      await storage.delete(key: 'refreshToken');
+      authNotifier.clear();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- import AzureAuthRemoteDataSource and read refresh token on startup
- refresh token and retry profile load if initial attempt fails
- clear stored tokens when refresh fails

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895882a08b08331971f68b519d68e66