### PR TITLE
Load auth tokens from secure storage before refresh

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ Future<void> _initAuth(AuthNotifier authNotifier) async {
     }
     final authRemoteDataSource =
         AzureAuthRemoteDataSource.create(secureStorage: storage);
+    await authRemoteDataSource.loadFromStorage();
     try {
       final newToken = await authRemoteDataSource.refreshToken();
       client = ClienteHttp(token: newToken);

--- a/test/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source_test.dart
+++ b/test/features/autenticacion/datos/fuentes_datos/azure_auth_remote_data_source_test.dart
@@ -80,6 +80,10 @@ void main() {
         await secureStorage.read(key: 'refreshToken'),
         fakeAppAuth.refreshToken,
       );
+      expect(
+        await secureStorage.read(key: 'idToken'),
+        fakeAppAuth.idToken,
+      );
     });
 
     test('login throws AzureAuthException on failure', () async {
@@ -115,12 +119,23 @@ void main() {
       await dataSource.logout();
       expect(await secureStorage.read(key: 'accessToken'), isNull);
       expect(await secureStorage.read(key: 'refreshToken'), isNull);
+      expect(await secureStorage.read(key: 'idToken'), isNull);
     });
 
     test('logout throws AzureAuthException when endSession fails', () async {
       await dataSource.login();
       fakeAppAuth.shouldThrow = true;
       expect(dataSource.logout, throwsA(isA<AzureAuthException>()));
+    });
+
+    test('refreshToken uses stored token when not loaded', () async {
+      await secureStorage.write(key: 'refreshToken', value: 'storedRefresh');
+      await secureStorage.write(key: 'idToken', value: 'storedId');
+      fakeAppAuth.accessToken = 'newAccess';
+      fakeAppAuth.refreshToken = 'newRefresh';
+      final token = await dataSource.refreshToken();
+      expect(token, 'newAccess');
+      expect(fakeAppAuth.lastRefreshToken, 'storedRefresh');
     });
   });
 }


### PR DESCRIPTION
## Summary
- add `loadFromStorage` to restore refresh and ID tokens from secure storage
- persist ID tokens on login and clear on logout
- refresh tokens lazily load from storage and main initialization uses it
- expand tests for token storage and loading from secure storage

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68958b77a7688331affa8d94d8a3bf30