### PR TITLE
feat: add base response model

### DIFF
--- a/lib/core/red/cliente_http.dart
+++ b/lib/core/red/cliente_http.dart
@@ -1,3 +1,5 @@
+export 'respuesta_base.dart';
+
 import 'package:http/http.dart' as http;
 
 /// A simple HTTP client that injects an Azure AD bearer token into every

--- a/lib/core/red/respuesta_base.dart
+++ b/lib/core/red/respuesta_base.dart
@@ -1,0 +1,29 @@
+class RespuestaBase<T> {
+  static const int RESPUESTA_CORRECTA = 1;
+  static const int RESPUESTA_ERROR = -1;
+
+  final int codigoRespuesta;
+  final T? respuesta;
+  final String? mensajeError;
+
+  const RespuestaBase({
+    required this.codigoRespuesta,
+    this.respuesta,
+    this.mensajeError,
+  });
+
+  static RespuestaBase<T> respuestaCorrecta<T>(T data) {
+    return RespuestaBase<T>(
+      codigoRespuesta: RESPUESTA_CORRECTA,
+      respuesta: data,
+    );
+  }
+
+  static RespuestaBase<T> respuestaError<T>(String mensaje) {
+    return RespuestaBase<T>(
+      codigoRespuesta: RESPUESTA_ERROR,
+      mensajeError: mensaje,
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add generic base response model
- export response base from HTTP client
- use 1/-1 codes for success and error constants

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689592f085b88331a2e48efabdef100f