### PR TITLE
test: add perfil and visits remote data source tests

### DIFF
--- a/test/features/autenticacion/datos/fuentes_datos/perfil_remote_data_source_test.dart
+++ b/test/features/autenticacion/datos/fuentes_datos/perfil_remote_data_source_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/fuentes_datos/perfil_remote_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
+
+void main() {
+  group('PerfilRemoteDataSource', () {
+    test('obtenerPerfil retorna usuario en exito', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response(
+          jsonEncode({
+            'id': '1',
+            'nombre': 'Juan',
+            'correo': 'juan@example.com',
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final client = ClienteHttp(token: 'token', inner: mockClient);
+      final dataSource = PerfilRemoteDataSource(client);
+
+      final result = await dataSource.obtenerPerfil();
+
+      expect(result.codigoRespuesta, RespuestaBase.RESPUESTA_CORRECTA);
+      final usuario = result.respuesta;
+      expect(usuario, isA<Usuario>());
+      expect(usuario!.id, '1');
+      expect(usuario.nombre, 'Juan');
+      expect(usuario.correo, 'juan@example.com');
+    });
+
+    test('obtenerPerfil retorna error en fallo', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('Not Found', 404);
+      });
+      final client = ClienteHttp(token: 'token', inner: mockClient);
+      final dataSource = PerfilRemoteDataSource(client);
+
+      final result = await dataSource.obtenerPerfil();
+
+      expect(result.codigoRespuesta, RespuestaBase.RESPUESTA_ERROR);
+      expect(result.respuesta, isNull);
+      expect(result.mensajeError, 'Error al obtener el perfil: 404');
+    });
+  });
+}
+

--- a/test/features/autenticacion/datos/fuentes_datos/visits_remote_data_source_test.dart
+++ b/test/features/autenticacion/datos/fuentes_datos/visits_remote_data_source_test.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/visitas/datos/fuentes_datos/visits_remote_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/visitas/datos/modelos/visita_model.dart';
+
+void main() {
+  group('VisitsRemoteDataSource', () {
+    test('obtenerVisitas retorna lista en exito', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response(
+          jsonEncode([
+            {
+              'id': 'v1',
+              'general': {
+                'estado': 'PROGRAMADA',
+                'fechaProgramada': '2023-01-01T00:00:00.000Z',
+                'fechaEjecucion': null,
+                'observaciones': null,
+              },
+              'proveedor': {'id': 'p1', 'nombre': 'Proveedor 1'},
+              'tipoVisita': {'id': 't1', 'descripcion': 'Tipo'},
+              'derechoMinero': {
+                'id': 'd1',
+                'codigo': 'DM1',
+                'nombre': 'Derecho 1',
+              },
+            }
+          ]),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final client = ClienteHttp(token: 'token', inner: mockClient);
+      final dataSource = VisitsRemoteDataSource(client);
+
+      final result = await dataSource.obtenerVisitas('g1');
+
+      expect(result.codigoRespuesta, RespuestaBase.RESPUESTA_CORRECTA);
+      final visitas = result.respuesta;
+      expect(visitas, isA<List<VisitaModel>>());
+      expect(visitas, hasLength(1));
+      expect(visitas![0].id, 'v1');
+      expect(visitas[0].proveedor.nombre, 'Proveedor 1');
+    });
+
+    test('obtenerVisitas retorna error en fallo', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('Server error', 500);
+      });
+      final client = ClienteHttp(token: 'token', inner: mockClient);
+      final dataSource = VisitsRemoteDataSource(client);
+
+      final result = await dataSource.obtenerVisitas('g1');
+
+      expect(result.codigoRespuesta, RespuestaBase.RESPUESTA_ERROR);
+      expect(result.respuesta, isNull);
+      expect(result.mensajeError, 'Error al obtener visitas: 500');
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add success and error tests for PerfilRemoteDataSource
- add success and error tests for VisitsRemoteDataSource

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68959bbfad648331a54e206a0b18cc6a