### PR TITLE
Handle API response codes

### DIFF
--- a/docs/respuesta_base.md
+++ b/docs/respuesta_base.md
@@ -1,0 +1,19 @@
+# Uso de `RespuestaBase`
+
+Las respuestas de la API se envuelven en un objeto JSON con la siguiente estructura:
+
+```json
+{
+  "codigoRespuesta": 1,
+  "respuesta": {},
+  "mensaje": "Descripción del error opcional"
+}
+```
+
+* `codigoRespuesta` indica si la petición fue exitosa (`1`) o si ocurrió un error (`-1`).
+* `respuesta` contiene los datos específicos de la operación cuando `codigoRespuesta` es correcto.
+* `mensaje` es un texto opcional que describe el error cuando `codigoRespuesta` es negativo.
+
+Las fuentes de datos remotas deben analizar este formato y convertirlo en instancias de la clase `RespuestaBase<T>`. Los consumidores (por ejemplo, BLoCs, widgets o servicios) deben inspeccionar `codigoRespuesta` antes de usar el valor de `respuesta` y manejar adecuadamente los mensajes de error.
+
+Este patrón garantiza una gestión coherente de errores y facilita la propagación de advertencias desde la capa de datos hasta la interfaz de usuario.

--- a/lib/features/perfil/datos/fuentes_datos/perfil_remote_data_source.dart
+++ b/lib/features/perfil/datos/fuentes_datos/perfil_remote_data_source.dart
@@ -23,8 +23,17 @@ class PerfilRemoteDataSource {
     if (response.statusCode == 200) {
       final Map<String, dynamic> data =
           jsonDecode(response.body) as Map<String, dynamic>;
-      final usuario = Usuario.fromJson(data);
-      return RespuestaBase.respuestaCorrecta(usuario);
+      final codigo = data['codigoRespuesta'] as int?;
+      if (codigo == RespuestaBase.RESPUESTA_CORRECTA &&
+          data['respuesta'] != null) {
+        final usuario =
+            Usuario.fromJson(data['respuesta'] as Map<String, dynamic>);
+        return RespuestaBase.respuestaCorrecta(usuario);
+      } else {
+        return RespuestaBase.respuestaError(
+          data['mensaje']?.toString() ?? 'Error al obtener el perfil',
+        );
+      }
     } else {
       return RespuestaBase.respuestaError(
         'Error al obtener el perfil: ${response.statusCode}',

--- a/lib/features/visitas/datos/fuentes_datos/visits_remote_data_source.dart
+++ b/lib/features/visitas/datos/fuentes_datos/visits_remote_data_source.dart
@@ -24,11 +24,20 @@ class VisitsRemoteDataSource {
     final response = await _client.get(uri);
 
     if (response.statusCode == 200) {
-      final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
-      final visitas = data
-          .map((json) => VisitaModel.fromJson(json as Map<String, dynamic>))
-          .toList();
-      return RespuestaBase.respuestaCorrecta(visitas);
+      final Map<String, dynamic> data =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      final codigo = data['codigoRespuesta'] as int?;
+      if (codigo == RespuestaBase.RESPUESTA_CORRECTA &&
+          data['respuesta'] is List) {
+        final visitas = (data['respuesta'] as List<dynamic>)
+            .map((json) => VisitaModel.fromJson(json as Map<String, dynamic>))
+            .toList();
+        return RespuestaBase.respuestaCorrecta(visitas);
+      } else {
+        return RespuestaBase.respuestaError(
+          data['mensaje']?.toString() ?? 'Error al obtener visitas',
+        );
+      }
     } else {
       return RespuestaBase.respuestaError(
         'Error al obtener visitas: ${response.statusCode}',

--- a/test/features/autenticacion/datos/fuentes_datos/perfil_remote_data_source_test.dart
+++ b/test/features/autenticacion/datos/fuentes_datos/perfil_remote_data_source_test.dart
@@ -14,9 +14,12 @@ void main() {
       final mockClient = MockClient((request) async {
         return http.Response(
           jsonEncode({
-            'id': '1',
-            'nombre': 'Juan',
-            'correo': 'juan@example.com',
+            'codigoRespuesta': 1,
+            'respuesta': {
+              'id': '1',
+              'nombre': 'Juan',
+              'correo': 'juan@example.com',
+            }
           }),
           200,
           headers: {'content-type': 'application/json'},
@@ -37,7 +40,14 @@ void main() {
 
     test('obtenerPerfil retorna error en fallo', () async {
       final mockClient = MockClient((request) async {
-        return http.Response('Not Found', 404);
+        return http.Response(
+          jsonEncode({
+            'codigoRespuesta': -1,
+            'mensaje': 'Perfil no encontrado',
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
       });
       final client = ClienteHttp(token: 'token', inner: mockClient);
       final dataSource = PerfilRemoteDataSource(client);
@@ -46,7 +56,7 @@ void main() {
 
       expect(result.codigoRespuesta, RespuestaBase.RESPUESTA_ERROR);
       expect(result.respuesta, isNull);
-      expect(result.mensajeError, 'Error al obtener el perfil: 404');
+      expect(result.mensajeError, 'Perfil no encontrado');
     });
   });
 }

--- a/test/features/autenticacion/datos/fuentes_datos/visits_remote_data_source_test.dart
+++ b/test/features/autenticacion/datos/fuentes_datos/visits_remote_data_source_test.dart
@@ -13,24 +13,27 @@ void main() {
     test('obtenerVisitas retorna lista en exito', () async {
       final mockClient = MockClient((request) async {
         return http.Response(
-          jsonEncode([
-            {
-              'id': 'v1',
-              'general': {
-                'estado': 'PROGRAMADA',
-                'fechaProgramada': '2023-01-01T00:00:00.000Z',
-                'fechaEjecucion': null,
-                'observaciones': null,
-              },
-              'proveedor': {'id': 'p1', 'nombre': 'Proveedor 1'},
-              'tipoVisita': {'id': 't1', 'descripcion': 'Tipo'},
-              'derechoMinero': {
-                'id': 'd1',
-                'codigo': 'DM1',
-                'nombre': 'Derecho 1',
-              },
-            }
-          ]),
+          jsonEncode({
+            'codigoRespuesta': 1,
+            'respuesta': [
+              {
+                'id': 'v1',
+                'general': {
+                  'estado': 'PROGRAMADA',
+                  'fechaProgramada': '2023-01-01T00:00:00.000Z',
+                  'fechaEjecucion': null,
+                  'observaciones': null,
+                },
+                'proveedor': {'id': 'p1', 'nombre': 'Proveedor 1'},
+                'tipoVisita': {'id': 't1', 'descripcion': 'Tipo'},
+                'derechoMinero': {
+                  'id': 'd1',
+                  'codigo': 'DM1',
+                  'nombre': 'Derecho 1',
+                },
+              }
+            ]
+          }),
           200,
           headers: {'content-type': 'application/json'},
         );
@@ -50,7 +53,14 @@ void main() {
 
     test('obtenerVisitas retorna error en fallo', () async {
       final mockClient = MockClient((request) async {
-        return http.Response('Server error', 500);
+        return http.Response(
+          jsonEncode({
+            'codigoRespuesta': -1,
+            'mensaje': 'No se pudo obtener visitas',
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
       });
       final client = ClienteHttp(token: 'token', inner: mockClient);
       final dataSource = VisitsRemoteDataSource(client);
@@ -59,7 +69,7 @@ void main() {
 
       expect(result.codigoRespuesta, RespuestaBase.RESPUESTA_ERROR);
       expect(result.respuesta, isNull);
-      expect(result.mensajeError, 'Error al obtener visitas: 500');
+      expect(result.mensajeError, 'No se pudo obtener visitas');
     });
   });
 }


### PR DESCRIPTION
## Summary
- inspect `codigoRespuesta` in profile and visits remote data sources to propagate errors from API responses
- add documentation on using `RespuestaBase` and update tests accordingly

## Testing
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68959d98254c833193dc94ed1111fbd6