### PR TITLE
feat: extend visita entity with users and metadata

### DIFF
--- a/lib/features/visitas/dominio/entidades/visita.dart
+++ b/lib/features/visitas/dominio/entidades/visita.dart
@@ -2,6 +2,7 @@ import 'derecho_minero.dart';
 import 'general.dart';
 import 'proveedor.dart';
 import 'tipo_visita.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
 
 /// Representa una visita programada a un derecho minero.
 class Visita {
@@ -20,6 +21,33 @@ class Visita {
   /// Derecho minero asociado a la visita.
   final DerechoMinero derechoMinero;
 
+  /// Usuario que creó la visita.
+  final Usuario creador;
+
+  /// Usuario geólogo asignado a la visita.
+  final Usuario? geologo;
+
+  /// Usuario acopiador asignado a la visita.
+  final Usuario? acopiador;
+
+  /// Fecha programada para la visita.
+  final DateTime? fechaProgramada;
+
+  /// Fecha de creación de la visita.
+  final DateTime fechaCreacion;
+
+  /// Indica si se realizó la medición de capacidad.
+  final bool flagMedicionCapacidad;
+
+  /// Código del departamento donde se realizará la visita.
+  final String codigoDepartamento;
+
+  /// Código de la provincia donde se realizará la visita.
+  final String codigoProvincia;
+
+  /// Código del distrito donde se realizará la visita.
+  final String codigoDistrito;
+
   /// Crea una instancia de [Visita].
   const Visita({
     required this.id,
@@ -27,6 +55,15 @@ class Visita {
     required this.proveedor,
     required this.tipoVisita,
     required this.derechoMinero,
+    required this.creador,
+    this.geologo,
+    this.acopiador,
+    this.fechaProgramada,
+    required this.fechaCreacion,
+    required this.flagMedicionCapacidad,
+    required this.codigoDepartamento,
+    required this.codigoProvincia,
+    required this.codigoDistrito,
   });
 
   /// Crea una [Visita] a partir de un mapa JSON.
@@ -39,6 +76,22 @@ class Visita {
             TipoVisita.fromJson(json['TipoVisita'] as Map<String, dynamic>),
         derechoMinero: DerechoMinero.fromJson(
             json['DerechoMinero'] as Map<String, dynamic>),
+        creador: Usuario.fromJson(
+            json['UsuarioCreador'] as Map<String, dynamic>),
+        geologo: json['Geologo'] != null
+            ? Usuario.fromJson(json['Geologo'] as Map<String, dynamic>)
+            : null,
+        acopiador: json['Acopiador'] != null
+            ? Usuario.fromJson(json['Acopiador'] as Map<String, dynamic>)
+            : null,
+        fechaProgramada: json['FechaProgramada'] != null
+            ? DateTime.parse(json['FechaProgramada'] as String)
+            : null,
+        fechaCreacion: DateTime.parse(json['FechaCreacion'] as String),
+        flagMedicionCapacidad: json['FlagMedicionCapacidad'] as bool,
+        codigoDepartamento: json['CodigoDepartamento'] as String,
+        codigoProvincia: json['CodigoProvincia'] as String,
+        codigoDistrito: json['CodigoDistrito'] as String,
       );
 
   /// Convierte la visita en un mapa JSON.
@@ -48,5 +101,14 @@ class Visita {
         'Proveedor': proveedor.toJson(),
         'TipoVisita': tipoVisita.toJson(),
         'DerechoMinero': derechoMinero.toJson(),
+        'UsuarioCreador': creador.toJson(),
+        'Geologo': geologo?.toJson(),
+        'Acopiador': acopiador?.toJson(),
+        'FechaProgramada': fechaProgramada?.toIso8601String(),
+        'FechaCreacion': fechaCreacion.toIso8601String(),
+        'FlagMedicionCapacidad': flagMedicionCapacidad,
+        'CodigoDepartamento': codigoDepartamento,
+        'CodigoProvincia': codigoProvincia,
+        'CodigoDistrito': codigoDistrito,
       };
 }


### PR DESCRIPTION
## Summary
- add creator, geologist and acopiador users to Visita
- support scheduling and location metadata on Visita

## Testing
- `dart format lib/features/visitas/dominio/entidades/visita.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897ec9cb1788331953cc262a02ae79a