### PR TITLE
feat: extend visit model with user and location fields

### DIFF
--- a/lib/features/visitas/datos/fuentes_datos/visits_local_data_source.dart
+++ b/lib/features/visitas/datos/fuentes_datos/visits_local_data_source.dart
@@ -18,7 +18,7 @@ class VisitsLocalDataSource {
       for (final visit in visits) {
         await _bdLocal.insert(ServicioBdLocal.nombreTablaVisitas, {
           'id': visit.id,
-          'estado': visit.general.estado,
+          'estado': visit.estado.estado,
           'data': jsonEncode(visit.toJson()),
         });
       }
@@ -33,7 +33,7 @@ class VisitsLocalDataSource {
       await _bdLocal.update(
         ServicioBdLocal.nombreTablaVisitas,
         {
-          'estado': visit.general.estado,
+          'estado': visit.estado.estado,
           'data': jsonEncode(visit.toJson()),
         },
         where: 'id = ?',

--- a/lib/features/visitas/datos/fuentes_datos/visits_remote_data_source.dart
+++ b/lib/features/visitas/datos/fuentes_datos/visits_remote_data_source.dart
@@ -26,21 +26,28 @@ class VisitsRemoteDataSource {
     if (response.statusCode == 200) {
       final Map<String, dynamic> data =
           jsonDecode(response.body) as Map<String, dynamic>;
-      final codigo = data['CodigoRespuesta'] as int?;
+      final codigo =
+          data['CodigoRespuesta'] as int? ?? RespuestaBase.RESPUESTA_ERROR;
       if (codigo == RespuestaBase.RESPUESTA_CORRECTA &&
           data['Respuesta'] is List) {
         final visitas = (data['Respuesta'] as List<dynamic>)
             .map((json) => VisitaModel.fromJson(json as Map<String, dynamic>))
             .toList();
-        return RespuestaBase.respuestaCorrecta(visitas);
+        return RespuestaBase(
+          codigoRespuesta: codigo,
+          respuesta: visitas,
+        );
       } else {
-        return RespuestaBase.respuestaError(
-          data['MensajeError']?.toString() ?? 'Error al obtener visitas',
+        return RespuestaBase(
+          codigoRespuesta: codigo,
+          mensajeError:
+              data['MensajeError']?.toString() ?? 'Error al obtener visitas',
         );
       }
     } else {
-      return RespuestaBase.respuestaError(
-        'Error al obtener visitas: ${response.statusCode}',
+      return RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
+        mensajeError: 'Error al obtener visitas: ${response.statusCode}',
       );
     }
   }

--- a/lib/features/visitas/datos/modelos/visita_model.dart
+++ b/lib/features/visitas/datos/modelos/visita_model.dart
@@ -3,6 +3,7 @@ import '../../dominio/entidades/general.dart';
 import '../../dominio/entidades/proveedor.dart';
 import '../../dominio/entidades/tipo_visita.dart';
 import '../../dominio/entidades/visita.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
 
 /// Modelo que representa una visita obtenida desde fuentes de datos.
 ///
@@ -12,16 +13,25 @@ class VisitaModel extends Visita {
   /// Crea una instancia de [VisitaModel].
   const VisitaModel({
     required super.id,
-    required super.general,
+    required super.estado,
     required super.proveedor,
     required super.tipoVisita,
     required super.derechoMinero,
+    required super.creador,
+    super.geologo,
+    super.acopiador,
+    super.fechaProgramada,
+    required super.fechaCreacion,
+    required super.flagMedicionCapacidad,
+    required super.codigoDepartamento,
+    required super.codigoProvincia,
+    required super.codigoDistrito,
   });
 
   /// Crea un [VisitaModel] a partir de un mapa JSON.
   factory VisitaModel.fromJson(Map<String, dynamic> json) => VisitaModel(
         id: json['Id'] as String,
-        general: General.fromJson(json['Estado'] as Map<String, dynamic>),
+        estado: General.fromJson(json['Estado'] as Map<String, dynamic>),
         proveedor:
             Proveedor.fromJson(json['Proveedor'] as Map<String, dynamic>),
         tipoVisita:
@@ -29,16 +39,41 @@ class VisitaModel extends Visita {
         derechoMinero: DerechoMinero.fromJson(
           json['DerechoMinero'] as Map<String, dynamic>,
         ),
+        creador:
+            Usuario.fromJson(json['UsuarioCreador'] as Map<String, dynamic>),
+        geologo: json['Geologo'] != null
+            ? Usuario.fromJson(json['Geologo'] as Map<String, dynamic>)
+            : null,
+        acopiador: json['Acopiador'] != null
+            ? Usuario.fromJson(json['Acopiador'] as Map<String, dynamic>)
+            : null,
+        fechaProgramada: json['FechaProgramada'] != null
+            ? DateTime.parse(json['FechaProgramada'] as String)
+            : null,
+        fechaCreacion: DateTime.parse(json['FechaCreacion'] as String),
+        flagMedicionCapacidad: json['FlagMedicionCapacidad'] as bool,
+        codigoDepartamento: json['CodigoDepartamento'] as String,
+        codigoProvincia: json['CodigoProvincia'] as String,
+        codigoDistrito: json['CodigoDistrito'] as String,
       );
 
   /// Convierte el modelo en un mapa JSON compatible con la API.
   @override
   Map<String, dynamic> toJson() => {
         'Id': id,
-        'General': general.toJson(),
+        'General': estado.toJson(),
         'Proveedor': proveedor.toJson(),
         'TipoVisita': tipoVisita.toJson(),
         'DerechoMinero': derechoMinero.toJson(),
+        'UsuarioCreador': creador.toJson(),
+        'Geologo': geologo?.toJson(),
+        'Acopiador': acopiador?.toJson(),
+        'FechaProgramada': fechaProgramada?.toIso8601String(),
+        'FechaCreacion': fechaCreacion.toIso8601String(),
+        'FlagMedicionCapacidad': flagMedicionCapacidad,
+        'CodigoDepartamento': codigoDepartamento,
+        'CodigoProvincia': codigoProvincia,
+        'CodigoDistrito': codigoDistrito,
       };
 }
 

--- a/lib/features/visitas/datos/repositorios/visits_repository_impl.dart
+++ b/lib/features/visitas/datos/repositorios/visits_repository_impl.dart
@@ -22,7 +22,7 @@ class VisitsRepositoryImpl implements VisitsRepository {
       await _localDataSource.insertVisits(remotas);
       final Map<String, List<Visita>> agrupadas = {};
       for (final visita in remotas) {
-        agrupadas.putIfAbsent(visita.general.estado, () => []).add(visita);
+        agrupadas.putIfAbsent(visita.estado.estado, () => []).add(visita);
       }
       return (visitas: agrupadas, advertencia: null);
     } else {

--- a/lib/features/visitas/presentacion/componentes/visit_card.dart
+++ b/lib/features/visitas/presentacion/componentes/visit_card.dart
@@ -18,7 +18,7 @@ class VisitCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fecha = visita.general.fechaProgramada;
+    final fecha = visita.estado.fechaProgramada;
     final fechaStr =
         '${fecha.day.toString().padLeft(2, '0')}/${fecha.month.toString().padLeft(2, '0')}/${fecha.year}';
 


### PR DESCRIPTION
## Summary
- expand `VisitaModel` with creator, assignees, dates and ubigeo data
- map API responses to the new visit structure and surface server codes
- adjust repository, local cache and UI to use the updated visit model

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f1c1bc1483319037a92607695efb