### PR TITLE
Use top-level visit fields and show ubigeo codes

### DIFF
--- a/lib/features/visitas/dominio/entidades/estado_visita.dart
+++ b/lib/features/visitas/dominio/entidades/estado_visita.dart
@@ -1,0 +1,13 @@
+/// Constantes que representan los estados de una visita.
+class EstadoVisita {
+  EstadoVisita._();
+
+  /// Visita programada.
+  static const String programada = 'PROGRAMADA';
+
+  /// Visita en proceso.
+  static const String enProceso = 'EN_PROCESO';
+
+  /// Visita finalizada.
+  static const String finalizada = 'FINALIZADA';
+}

--- a/lib/features/visitas/presentacion/bloc/visitas_bloc.dart
+++ b/lib/features/visitas/presentacion/bloc/visitas_bloc.dart
@@ -2,7 +2,7 @@ import 'package:bloc/bloc.dart';
 
 import '../../datos/fuentes_datos/visits_local_data_source.dart'
     show VisitsLocalException;
-import '../../dominio/entidades/general.dart';
+import '../../dominio/entidades/estado_visita.dart';
 import '../../dominio/entidades/visita.dart';
 import '../../dominio/repositorios/visits_repository.dart';
 
@@ -26,11 +26,10 @@ class VisitasBloc extends Bloc<VisitasEvent, VisitasState> {
       final resultado =
           await _repository.obtenerVisitasPorGeologo(event.idGeologo);
       final programadas =
-          resultado.visitas[General.ESTADO_VISITA_PROGRAMADA] ?? [];
-      final borrador =
-          resultado.visitas[General.ESTADO_VISITA_EN_PROCESO] ?? [];
+          resultado.visitas[EstadoVisita.programada] ?? [];
+      final borrador = resultado.visitas[EstadoVisita.enProceso] ?? [];
       final completadas =
-          resultado.visitas[General.ESTADO_VISITA_FINALIZADA] ?? [];
+          resultado.visitas[EstadoVisita.finalizada] ?? [];
       emit(VisitasCargadas(
         programadas: programadas,
         borrador: borrador,

--- a/lib/features/visitas/presentacion/componentes/visit_card.dart
+++ b/lib/features/visitas/presentacion/componentes/visit_card.dart
@@ -18,9 +18,10 @@ class VisitCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fecha = visita.estado.fechaProgramada;
-    final fechaStr =
-        '${fecha.day.toString().padLeft(2, '0')}/${fecha.month.toString().padLeft(2, '0')}/${fecha.year}';
+    final fecha = visita.fechaProgramada;
+    final fechaStr = fecha != null
+        ? '${fecha.day.toString().padLeft(2, '0')}/${fecha.month.toString().padLeft(2, '0')}/${fecha.year}'
+        : '-';
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -38,6 +39,9 @@ class VisitCard extends StatelessWidget {
             Text('Proveedor: ${visita.proveedor.nombre}'),
             Text('Derecho minero: ${visita.derechoMinero.nombre}'),
             Text('Acopiador: $acopiador'),
+            Text(
+              'Ubigeo: ${visita.codigoDepartamento}-${visita.codigoProvincia}-${visita.codigoDistrito}',
+            ),
             Text('Fecha: $fechaStr'),
           ],
         ),


### PR DESCRIPTION
## Summary
- Display `fechaProgramada` directly from `Visita` and show Ubigeo codes in visit cards
- Replace `General` references with new `EstadoVisita` constants in visits bloc
- Introduce `EstadoVisita` constants for visit statuses

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6897f7026f008331b3740c5d3727a97a