### PR TITLE
feat: add general data sources and repository

### DIFF
--- a/lib/features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart
+++ b/lib/features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart
@@ -1,0 +1,107 @@
+import 'package:sqflite/sqflite.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/core/servicios/servicio_bd_local.dart';
+
+import '../../dominio/entidades/inicio_proceso_formalizacion.dart';
+import '../../dominio/entidades/tipo_proveedor.dart';
+
+/// Fuente de datos local para almacenar y recuperar listas generales.
+class GeneralLocalDataSource {
+  GeneralLocalDataSource(this._bdLocal);
+
+  final ServicioBdLocal _bdLocal;
+
+  static const String _tablaTiposProveedor = 'tipos_proveedor';
+  static const String _tablaIniciosFormalizacion =
+      'inicios_proceso_formalizacion';
+
+  Future<void> _crearTablasSiNoExisten() async {
+    final db = await _bdLocal.database;
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS $_tablaTiposProveedor(
+        id TEXT PRIMARY KEY,
+        descripcion TEXT
+      );
+    ''');
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS $_tablaIniciosFormalizacion(
+        id TEXT PRIMARY KEY,
+        descripcion TEXT
+      );
+    ''');
+  }
+
+  /// Reemplaza los tipos de proveedor almacenados.
+  Future<void> reemplazarTiposProveedor(List<TipoProveedor> tipos) async {
+    try {
+      await _crearTablasSiNoExisten();
+      final db = await _bdLocal.database;
+      await db.delete(_tablaTiposProveedor);
+      for (final tipo in tipos) {
+        await _bdLocal.insert(_tablaTiposProveedor, {
+          'id': tipo.id,
+          'descripcion': tipo.descripcion,
+        });
+      }
+    } on DatabaseException catch (e) {
+      throw GeneralLocalException('Error al guardar tipos proveedor: $e');
+    }
+  }
+
+  /// Obtiene los tipos de proveedor almacenados localmente.
+  Future<List<TipoProveedor>> obtenerTiposProveedor() async {
+    try {
+      await _crearTablasSiNoExisten();
+      final rows = await _bdLocal.query(_tablaTiposProveedor);
+      return rows
+          .map((row) =>
+              TipoProveedor(id: row['id'] as String, descripcion: row['descripcion'] as String))
+          .toList();
+    } on DatabaseException catch (e) {
+      throw GeneralLocalException('Error al obtener tipos proveedor: $e');
+    }
+  }
+
+  /// Reemplaza los inicios de proceso de formalización almacenados.
+  Future<void> reemplazarIniciosFormalizacion(
+      List<InicioProcesoFormalizacion> inicios) async {
+    try {
+      await _crearTablasSiNoExisten();
+      final db = await _bdLocal.database;
+      await db.delete(_tablaIniciosFormalizacion);
+      for (final inicio in inicios) {
+        await _bdLocal.insert(_tablaIniciosFormalizacion, {
+          'id': inicio.id,
+          'descripcion': inicio.descripcion,
+        });
+      }
+    } on DatabaseException catch (e) {
+      throw GeneralLocalException('Error al guardar inicios formalización: $e');
+    }
+  }
+
+  /// Obtiene los inicios de proceso de formalización almacenados.
+  Future<List<InicioProcesoFormalizacion>> obtenerIniciosFormalizacion() async {
+    try {
+      await _crearTablasSiNoExisten();
+      final rows = await _bdLocal.query(_tablaIniciosFormalizacion);
+      return rows
+          .map((row) => InicioProcesoFormalizacion(
+                id: row['id'] as String,
+                descripcion: row['descripcion'] as String,
+              ))
+          .toList();
+    } on DatabaseException catch (e) {
+      throw GeneralLocalException(
+          'Error al obtener inicios formalización: $e');
+    }
+  }
+}
+
+/// Excepción para errores de acceso a datos locales generales.
+class GeneralLocalException implements Exception {
+  GeneralLocalException(this.message);
+  final String message;
+  @override
+  String toString() => 'GeneralLocalException: $message';
+}

--- a/lib/features/flujo_visita/datos/fuentes_datos/general_remote_data_source.dart
+++ b/lib/features/flujo_visita/datos/fuentes_datos/general_remote_data_source.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:veta_dorada_vinculacion_mobile/core/config/environment_config.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+
+import '../../dominio/entidades/inicio_proceso_formalizacion.dart';
+import '../../dominio/entidades/tipo_proveedor.dart';
+
+/// Fuente de datos remota para obtener listas generales necesarias
+/// durante el flujo de visita.
+class GeneralRemoteDataSource {
+  GeneralRemoteDataSource(this._client);
+
+  final ClienteHttp _client;
+
+  /// Obtiene los tipos de proveedor disponibles.
+  Future<RespuestaBase<List<TipoProveedor>>> obtenerTiposProveedor() async {
+    final uri =
+        Uri.parse('${EnvironmentConfig.apiBaseUrl}/api/tipo-proveedor');
+    final response = await _client.get(uri);
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> data =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      final codigo =
+          data['CodigoRespuesta'] as int? ?? RespuestaBase.RESPUESTA_ERROR;
+      if (codigo == RespuestaBase.RESPUESTA_CORRECTA &&
+          data['Respuesta'] is List) {
+        final tipos = (data['Respuesta'] as List<dynamic>)
+            .map((e) => TipoProveedor.fromJson(e as Map<String, dynamic>))
+            .toList();
+        return RespuestaBase(codigoRespuesta: codigo, respuesta: tipos);
+      } else {
+        return RespuestaBase(
+          codigoRespuesta: codigo,
+          mensajeError: data['MensajeError']?.toString() ??
+              'Error al obtener tipos de proveedor',
+        );
+      }
+    } else {
+      return RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
+        mensajeError:
+            'Error al obtener tipos de proveedor: ${response.statusCode}',
+      );
+    }
+  }
+
+  /// Obtiene los inicios de proceso de formalización.
+  Future<RespuestaBase<List<InicioProcesoFormalizacion>>>
+      obtenerIniciosProcesoFormalizacion() async {
+    final uri = Uri.parse(
+        '${EnvironmentConfig.apiBaseUrl}/api/inicio-proceso-formalizacion');
+    final response = await _client.get(uri);
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> data =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      final codigo =
+          data['CodigoRespuesta'] as int? ?? RespuestaBase.RESPUESTA_ERROR;
+      if (codigo == RespuestaBase.RESPUESTA_CORRECTA &&
+          data['Respuesta'] is List) {
+        final inicios = (data['Respuesta'] as List<dynamic>)
+            .map((e) =>
+                InicioProcesoFormalizacion.fromJson(e as Map<String, dynamic>))
+            .toList();
+        return RespuestaBase(codigoRespuesta: codigo, respuesta: inicios);
+      } else {
+        return RespuestaBase(
+          codigoRespuesta: codigo,
+          mensajeError: data['MensajeError']?.toString() ??
+              'Error al obtener inicios de formalización',
+        );
+      }
+    } else {
+      return RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
+        mensajeError:
+            'Error al obtener inicios de formalización: ${response.statusCode}',
+      );
+    }
+  }
+}

--- a/lib/features/flujo_visita/datos/repositorios/general_repository.dart
+++ b/lib/features/flujo_visita/datos/repositorios/general_repository.dart
@@ -1,0 +1,49 @@
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+
+import '../../dominio/entidades/inicio_proceso_formalizacion.dart';
+import '../../dominio/entidades/tipo_proveedor.dart';
+import '../fuentes_datos/general_local_data_source.dart';
+import '../fuentes_datos/general_remote_data_source.dart';
+
+/// Repositorio que coordina la obtención y almacenamiento de datos generales
+/// utilizados en el flujo de visita.
+class GeneralRepository {
+  GeneralRepository(this._remoteDataSource, this._localDataSource);
+
+  final GeneralRemoteDataSource _remoteDataSource;
+  final GeneralLocalDataSource _localDataSource;
+
+  /// Obtiene los tipos de proveedor desde la API y los almacena localmente.
+  ///
+  /// Si la consulta remota falla, se intenta devolver los datos almacenados
+  /// localmente y se incluye un mensaje de advertencia.
+  Future<({List<TipoProveedor> tipos, String? advertencia})>
+      obtenerTiposProveedor() async {
+    final respuesta = await _remoteDataSource.obtenerTiposProveedor();
+    if (respuesta.codigoRespuesta == RespuestaBase.RESPUESTA_CORRECTA &&
+        respuesta.respuesta != null) {
+      await _localDataSource.reemplazarTiposProveedor(respuesta.respuesta!);
+      return (tipos: respuesta.respuesta!, advertencia: null);
+    } else {
+      final locales = await _localDataSource.obtenerTiposProveedor();
+      return (tipos: locales, advertencia: respuesta.mensajeError);
+    }
+  }
+
+  /// Obtiene los inicios de proceso de formalización desde la API y los
+  /// almacena localmente.
+  Future<({List<InicioProcesoFormalizacion> inicios, String? advertencia})>
+      obtenerIniciosFormalizacion() async {
+    final respuesta =
+        await _remoteDataSource.obtenerIniciosProcesoFormalizacion();
+    if (respuesta.codigoRespuesta == RespuestaBase.RESPUESTA_CORRECTA &&
+        respuesta.respuesta != null) {
+      await _localDataSource
+          .reemplazarIniciosFormalizacion(respuesta.respuesta!);
+      return (inicios: respuesta.respuesta!, advertencia: null);
+    } else {
+      final locales = await _localDataSource.obtenerIniciosFormalizacion();
+      return (inicios: locales, advertencia: respuesta.mensajeError);
+    }
+  }
+}

--- a/lib/features/flujo_visita/dominio/entidades/inicio_proceso_formalizacion.dart
+++ b/lib/features/flujo_visita/dominio/entidades/inicio_proceso_formalizacion.dart
@@ -1,0 +1,25 @@
+/// Define un inicio de proceso de formalización.
+class InicioProcesoFormalizacion {
+  /// Identificador único del registro.
+  final String id;
+
+  /// Descripción del inicio de proceso.
+  final String descripcion;
+
+  /// Crea una instancia de [InicioProcesoFormalizacion].
+  const InicioProcesoFormalizacion(
+      {required this.id, required this.descripcion});
+
+  /// Crea un [InicioProcesoFormalizacion] a partir de un mapa JSON.
+  factory InicioProcesoFormalizacion.fromJson(Map<String, dynamic> json) =>
+      InicioProcesoFormalizacion(
+        id: json['id'] as String,
+        descripcion: json['descripcion'] as String,
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'descripcion': descripcion,
+      };
+}

--- a/lib/features/flujo_visita/dominio/entidades/tipo_proveedor.dart
+++ b/lib/features/flujo_visita/dominio/entidades/tipo_proveedor.dart
@@ -1,0 +1,23 @@
+/// Representa un tipo de proveedor disponible en el sistema.
+class TipoProveedor {
+  /// Identificador único del tipo de proveedor.
+  final String id;
+
+  /// Descripción del tipo de proveedor.
+  final String descripcion;
+
+  /// Crea una instancia de [TipoProveedor].
+  const TipoProveedor({required this.id, required this.descripcion});
+
+  /// Crea un [TipoProveedor] a partir de un mapa JSON.
+  factory TipoProveedor.fromJson(Map<String, dynamic> json) => TipoProveedor(
+        id: json['id'] as String,
+        descripcion: json['descripcion'] as String,
+      );
+
+  /// Convierte el [TipoProveedor] en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'descripcion': descripcion,
+      };
+}


### PR DESCRIPTION
## Summary
- add TipoProveedor and InicioProcesoFormalizacion entities
- implement remote and local data sources for general lists
- create GeneralRepository coordinating sync and local access

## Testing
- `dart format lib/features/flujo_visita/dominio/entidades/tipo_proveedor.dart lib/features/flujo_visita/dominio/entidades/inicio_proceso_formalizacion.dart lib/features/flujo_visita/datos/fuentes_datos/general_remote_data_source.dart lib/features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart lib/features/flujo_visita/datos/repositorios/general_repository.dart` (fails: command not found)
- `dart analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68980145ce5883319940bef0bfcc0456