### PR TITLE
feat: sync general catalogs

### DIFF
--- a/lib/core/servicios/servicio_bd_local.dart
+++ b/lib/core/servicios/servicio_bd_local.dart
@@ -17,6 +17,9 @@ class ServicioBdLocal {
   factory ServicioBdLocal() => _instancia;
 
   static const String nombreTablaVisitas = 'visitas';
+  static const String nombreTablaTipoProveedor = 'tipo_proveedor';
+  static const String nombreTablaInicioProcesoFormalizacion =
+      'inicio_proceso_formalizacion';
 
   static const _nombreBd = 'vinculacion.db';
   static const _versionBd = 1;
@@ -37,6 +40,18 @@ class ServicioBdLocal {
             id TEXT PRIMARY KEY,
             estado TEXT,
             data TEXT
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE $nombreTablaTipoProveedor(
+            id TEXT PRIMARY KEY,
+            descripcion TEXT
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE $nombreTablaInicioProcesoFormalizacion(
+            id TEXT PRIMARY KEY,
+            descripcion TEXT
           );
         ''');
       },
@@ -69,6 +84,20 @@ class ServicioBdLocal {
     return db.update(
       table,
       values,
+      where: where,
+      whereArgs: whereArgs,
+    );
+  }
+
+  /// Elimina registros de [table].
+  Future<int> delete(
+    String table, {
+    String? where,
+    List<Object?>? whereArgs,
+  }) async {
+    final db = await database;
+    return db.delete(
+      table,
       where: where,
       whereArgs: whereArgs,
     );

--- a/lib/features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart
+++ b/lib/features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart
@@ -11,32 +11,15 @@ class GeneralLocalDataSource {
 
   final ServicioBdLocal _bdLocal;
 
-  static const String _tablaTiposProveedor = 'tipos_proveedor';
+  static const String _tablaTiposProveedor =
+      ServicioBdLocal.nombreTablaTipoProveedor;
   static const String _tablaIniciosFormalizacion =
-      'inicios_proceso_formalizacion';
-
-  Future<void> _crearTablasSiNoExisten() async {
-    final db = await _bdLocal.database;
-    await db.execute('''
-      CREATE TABLE IF NOT EXISTS $_tablaTiposProveedor(
-        id TEXT PRIMARY KEY,
-        descripcion TEXT
-      );
-    ''');
-    await db.execute('''
-      CREATE TABLE IF NOT EXISTS $_tablaIniciosFormalizacion(
-        id TEXT PRIMARY KEY,
-        descripcion TEXT
-      );
-    ''');
-  }
+      ServicioBdLocal.nombreTablaInicioProcesoFormalizacion;
 
   /// Reemplaza los tipos de proveedor almacenados.
   Future<void> reemplazarTiposProveedor(List<TipoProveedor> tipos) async {
     try {
-      await _crearTablasSiNoExisten();
-      final db = await _bdLocal.database;
-      await db.delete(_tablaTiposProveedor);
+      await _bdLocal.delete(_tablaTiposProveedor);
       for (final tipo in tipos) {
         await _bdLocal.insert(_tablaTiposProveedor, {
           'id': tipo.id,
@@ -51,7 +34,6 @@ class GeneralLocalDataSource {
   /// Obtiene los tipos de proveedor almacenados localmente.
   Future<List<TipoProveedor>> obtenerTiposProveedor() async {
     try {
-      await _crearTablasSiNoExisten();
       final rows = await _bdLocal.query(_tablaTiposProveedor);
       return rows
           .map((row) =>
@@ -66,9 +48,7 @@ class GeneralLocalDataSource {
   Future<void> reemplazarIniciosFormalizacion(
       List<InicioProcesoFormalizacion> inicios) async {
     try {
-      await _crearTablasSiNoExisten();
-      final db = await _bdLocal.database;
-      await db.delete(_tablaIniciosFormalizacion);
+      await _bdLocal.delete(_tablaIniciosFormalizacion);
       for (final inicio in inicios) {
         await _bdLocal.insert(_tablaIniciosFormalizacion, {
           'id': inicio.id,
@@ -83,7 +63,6 @@ class GeneralLocalDataSource {
   /// Obtiene los inicios de proceso de formalización almacenados.
   Future<List<InicioProcesoFormalizacion>> obtenerIniciosFormalizacion() async {
     try {
-      await _crearTablasSiNoExisten();
       final rows = await _bdLocal.query(_tablaIniciosFormalizacion);
       return rows
           .map((row) => InicioProcesoFormalizacion(

--- a/lib/features/flujo_visita/datos/repositorios/general_repository.dart
+++ b/lib/features/flujo_visita/datos/repositorios/general_repository.dart
@@ -46,4 +46,31 @@ class GeneralRepository {
       return (inicios: locales, advertencia: respuesta.mensajeError);
     }
   }
+
+  /// Sincroniza los catálogos generales al inicio de la aplicación.
+  ///
+  /// Borra los datos existentes y descarga los registros más recientes desde
+  /// el repositorio remoto para almacenarlos localmente.
+  Future<void> sincronizarDatosGenerales() async {
+    final tiposRespuesta = await _remoteDataSource.obtenerTiposProveedor();
+    if (tiposRespuesta.codigoRespuesta ==
+            RespuestaBase.RESPUESTA_CORRECTA &&
+        tiposRespuesta.respuesta != null) {
+      await _localDataSource.reemplazarTiposProveedor(
+          tiposRespuesta.respuesta!);
+    } else {
+      await _localDataSource.reemplazarTiposProveedor(const []);
+    }
+
+    final iniciosRespuesta =
+        await _remoteDataSource.obtenerIniciosProcesoFormalizacion();
+    if (iniciosRespuesta.codigoRespuesta ==
+            RespuestaBase.RESPUESTA_CORRECTA &&
+        iniciosRespuesta.respuesta != null) {
+      await _localDataSource
+          .reemplazarIniciosFormalizacion(iniciosRespuesta.respuesta!);
+    } else {
+      await _localDataSource.reemplazarIniciosFormalizacion(const []);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- create local tables for provider types and formalization starts
- handle insert/delete of general catalog data
- add synchronization routine to refresh catalog tables on app start

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898038bffac83319168f1ddf603f90a