### PR TITLE
feat: add generic catalog item for provider

### DIFF
--- a/lib/features/visitas/dominio/entidades/catalogo_item.dart
+++ b/lib/features/visitas/dominio/entidades/catalogo_item.dart
@@ -1,0 +1,23 @@
+/// Elemento genérico de catálogo.
+class CatalogoItem {
+  /// Código identificador del ítem.
+  final String codigo;
+
+  /// Descripción del ítem.
+  final String descripcion;
+
+  /// Crea una instancia de [CatalogoItem].
+  const CatalogoItem({required this.codigo, required this.descripcion});
+
+  /// Crea un [CatalogoItem] a partir de un mapa JSON.
+  factory CatalogoItem.fromJson(Map<String, dynamic> json) => CatalogoItem(
+        codigo: json['codigo'] as String,
+        descripcion: json['descripcion'] as String,
+      );
+
+  /// Convierte el [CatalogoItem] en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'codigo': codigo,
+        'descripcion': descripcion,
+      };
+}

--- a/lib/features/visitas/dominio/entidades/proveedor.dart
+++ b/lib/features/visitas/dominio/entidades/proveedor.dart
@@ -1,6 +1,5 @@
-import 'package:veta_dorada_vinculacion_mobile/features/visitas/dominio/entidades/derecho_minero.dart';
-
-import 'general.dart';
+import 'derecho_minero.dart';
+import 'catalogo_item.dart';
 
 /// Representa al proveedor responsable de una visita.
 class Proveedor {
@@ -9,33 +8,102 @@ class Proveedor {
 
   /// Nombre o razón social del proveedor.
   final String nombre;
-  final General tipo;
+
+  /// Tipo de proveedor.
+  final CatalogoItem tipo;
+
+  /// RUC del proveedor.
   final String ruc;
+
+  /// Nombre completo del proveedor (si aplica).
   final String? nombreCompleto;
+
+  /// DNI del proveedor (si aplica).
   final String? dni;
+
+  /// Razón social del proveedor.
   final String? razonSocial;
+
+  /// Nombre del representante legal.
   final String? representanteNombre;
+
+  /// DNI del representante legal.
   final String? representanteDni;
-  final General estado;
+
+  /// Estado del proveedor.
+  final CatalogoItem estado;
+
+  /// Correo electrónico de contacto.
   final String? correoElectronico;
+
+  /// Teléfono de contacto.
   final String? telefono;
+
+  /// Whatsapp de la contadora.
   final String? whatsappContadora;
+
+  /// Documento firmado asociado al proveedor.
   final String? documentoFirmado;
+
+  /// Derechos mineros asociados al proveedor.
   final List<DerechoMinero>? derechoMinero;
 
-  /// Crea una instancia de [Provethis.tipo, this.ruc, this.nombreCompleto, this.dni, this.razonSocial, this.representanteNombre, this.representanteDni, this.estado, this.correoElectronico, this.telefono, this.whatsappContadora, this.documentoFirmado, this.derechoMinero, edor].
-  const Proveedor({required this.id, required this.nombre,required this.tipo,required this.ruc, this.nombreCompleto, this.dni, this.razonSocial, this.representanteNombre, this.representanteDni,required this.estado, this.correoElectronico, this.telefono, this.whatsappContadora, this.documentoFirmado, this.derechoMinero});
+  /// Crea una instancia de [Proveedor].
+  const Proveedor({
+    required this.id,
+    required this.nombre,
+    required this.tipo,
+    required this.ruc,
+    this.nombreCompleto,
+    this.dni,
+    this.razonSocial,
+    this.representanteNombre,
+    this.representanteDni,
+    required this.estado,
+    this.correoElectronico,
+    this.telefono,
+    this.whatsappContadora,
+    this.documentoFirmado,
+    this.derechoMinero,
+  });
 
   /// Crea un [Proveedor] a partir de un mapa JSON.
   factory Proveedor.fromJson(Map<String, dynamic> json) => Proveedor(
-        id: json['Id'] as String,
-        tipo: json['Nombre'] as String,
-
+        id: json['id'] as String,
+        nombre: json['nombre'] as String,
+        tipo: CatalogoItem.fromJson(json['tipo'] as Map<String, dynamic>),
+        ruc: json['ruc'] as String,
+        nombreCompleto: json['nombreCompleto'] as String?,
+        dni: json['dni'] as String?,
+        razonSocial: json['razonSocial'] as String?,
+        representanteNombre: json['representanteNombre'] as String?,
+        representanteDni: json['representanteDni'] as String?,
+        estado: CatalogoItem.fromJson(json['estado'] as Map<String, dynamic>),
+        correoElectronico: json['correoElectronico'] as String?,
+        telefono: json['telefono'] as String?,
+        whatsappContadora: json['whatsappContadora'] as String?,
+        documentoFirmado: json['documentoFirmado'] as String?,
+        derechoMinero: (json['derechoMinero'] as List<dynamic>?)
+            ?.map((e) => DerechoMinero.fromJson(e as Map<String, dynamic>))
+            .toList(),
       );
 
   /// Convierte el [Proveedor] en un mapa JSON.
   Map<String, dynamic> toJson() => {
         'id': id,
         'nombre': nombre,
+        'tipo': tipo.toJson(),
+        'ruc': ruc,
+        'nombreCompleto': nombreCompleto,
+        'dni': dni,
+        'razonSocial': razonSocial,
+        'representanteNombre': representanteNombre,
+        'representanteDni': representanteDni,
+        'estado': estado.toJson(),
+        'correoElectronico': correoElectronico,
+        'telefono': telefono,
+        'whatsappContadora': whatsappContadora,
+        'documentoFirmado': documentoFirmado,
+        'derechoMinero': derechoMinero?.map((e) => e.toJson()).toList(),
       };
 }

--- a/lib/features/visitas/dominio/entidades/visita.dart
+++ b/lib/features/visitas/dominio/entidades/visita.dart
@@ -9,7 +9,7 @@ class Visita {
   /// Identificador único de la visita.
   final String id;
 
-  /// Información general Ede la visita.
+  /// Información general de la visita.
   final General estado;
 
   /// Proveedor encargado de realizar la visita.
@@ -97,7 +97,7 @@ class Visita {
   /// Convierte la visita en un mapa JSON.
   Map<String, dynamic> toJson() => {
         'Id': id,
-        'General': estado.toJson(),
+        'Estado': estado.toJson(),
         'Proveedor': proveedor.toJson(),
         'TipoVisita': tipoVisita.toJson(),
         'DerechoMinero': derechoMinero.toJson(),

--- a/test/features/autenticacion/datos/fuentes_datos/visits_remote_data_source_test.dart
+++ b/test/features/autenticacion/datos/fuentes_datos/visits_remote_data_source_test.dart
@@ -24,7 +24,13 @@ void main() {
                   'fechaEjecucion': null,
                   'observaciones': null,
                 },
-                'proveedor': {'id': 'p1', 'nombre': 'Proveedor 1'},
+                'proveedor': {
+                  'id': 'p1',
+                  'nombre': 'Proveedor 1',
+                  'tipo': {'codigo': 'TP', 'descripcion': 'Tipo'},
+                  'ruc': '12345678901',
+                  'estado': {'codigo': 'ACT', 'descripcion': 'Activo'}
+                },
                 'tipoVisita': {'id': 't1', 'descripcion': 'Tipo'},
                 'derechoMinero': {
                   'id': 'd1',


### PR DESCRIPTION
## Summary
- add generic CatalogoItem entity for catalog entries
- refactor Proveedor to use CatalogoItem for tipo and estado and fully map JSON
- align Visita serialization with updated Proveedor structure
- adjust remote data source test with new proveedor fields

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68980bac57f883319aa0f1062bf3886b