### PR TITLE
feat: add OrigenActividad enum

### DIFF
--- a/lib/features/actividad/actividad.dart
+++ b/lib/features/actividad/actividad.dart
@@ -1,0 +1,1 @@
+export 'dominio/origen_actividad.dart';

--- a/lib/features/actividad/dominio/origen_actividad.dart
+++ b/lib/features/actividad/dominio/origen_actividad.dart
@@ -1,0 +1,47 @@
+enum OrigenActividad {
+  reinfo,
+  igafom,
+  verificada,
+  desconocido,
+}
+
+extension OrigenActividadApi on OrigenActividad {
+  int toApi() {
+    switch (this) {
+      case OrigenActividad.reinfo:
+        return 1;
+      case OrigenActividad.igafom:
+        return 2;
+      case OrigenActividad.verificada:
+        return 3;
+      case OrigenActividad.desconocido:
+        return 0;
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case OrigenActividad.reinfo:
+        return 'Reinfo';
+      case OrigenActividad.igafom:
+        return 'IGAFOM';
+      case OrigenActividad.verificada:
+        return 'Verificada';
+      case OrigenActividad.desconocido:
+        return 'Desconocido';
+    }
+  }
+}
+
+OrigenActividad origenFromApi(int? code) {
+  switch (code) {
+    case 1:
+      return OrigenActividad.reinfo;
+    case 2:
+      return OrigenActividad.igafom;
+    case 3:
+      return OrigenActividad.verificada;
+    default:
+      return OrigenActividad.desconocido;
+  }
+}


### PR DESCRIPTION
## Summary
- define `OrigenActividad` enum with API code mapping and human-friendly labels
- expose helper `origenFromApi` and export file for other modules

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68981b6a19f0833185f75773923f4728