### PR TITLE
feat: sync tipos actividad

### DIFF
--- a/lib/core/servicios/servicio_bd_local.dart
+++ b/lib/core/servicios/servicio_bd_local.dart
@@ -20,6 +20,7 @@ class ServicioBdLocal {
   static const String nombreTablaTipoProveedor = 'tipo_proveedor';
   static const String nombreTablaInicioProcesoFormalizacion =
       'inicio_proceso_formalizacion';
+  static const String nombreTablaTipoActividad = 'tipo_actividad';
 
   static const _nombreBd = 'vinculacion.db';
   static const _versionBd = 1;
@@ -51,6 +52,12 @@ class ServicioBdLocal {
         await db.execute('''
           CREATE TABLE $nombreTablaInicioProcesoFormalizacion(
             id TEXT PRIMARY KEY,
+            descripcion TEXT
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE $nombreTablaTipoActividad(
+            id INTEGER PRIMARY KEY,
             descripcion TEXT
           );
         ''');

--- a/lib/features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart
+++ b/lib/features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart
@@ -1,0 +1,54 @@
+import 'package:sqflite/sqflite.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/core/servicios/servicio_bd_local.dart';
+
+import '../../dominio/entidades/tipo_actividad.dart';
+
+/// Fuente de datos local para almacenar tipos de actividad.
+class TipoActividadLocalDataSource {
+  TipoActividadLocalDataSource(this._bdLocal);
+
+  final ServicioBdLocal _bdLocal;
+
+  static const String _tabla = ServicioBdLocal.nombreTablaTipoActividad;
+
+  /// Reemplaza los tipos de actividad almacenados por [tipos].
+  Future<void> reemplazarTiposActividad(List<TipoActividad> tipos) async {
+    try {
+      await _bdLocal.delete(_tabla);
+      for (final tipo in tipos) {
+        await _bdLocal.insert(_tabla, {
+          'id': tipo.id,
+          'descripcion': tipo.descripcion,
+        });
+      }
+    } on DatabaseException catch (e) {
+      throw TipoActividadLocalException(
+          'Error al guardar tipos de actividad: $e');
+    }
+  }
+
+  /// Obtiene los tipos de actividad almacenados localmente.
+  Future<List<TipoActividad>> obtenerTiposActividad() async {
+    try {
+      final rows = await _bdLocal.query(_tabla);
+      return rows
+          .map((row) => TipoActividad(
+                id: row['id'] as int,
+                descripcion: row['descripcion'] as String,
+              ))
+          .toList();
+    } on DatabaseException catch (e) {
+      throw TipoActividadLocalException(
+          'Error al obtener tipos de actividad: $e');
+    }
+  }
+}
+
+/// Excepción para errores de acceso a los datos locales de tipos de actividad.
+class TipoActividadLocalException implements Exception {
+  TipoActividadLocalException(this.message);
+  final String message;
+  @override
+  String toString() => 'TipoActividadLocalException: $message';
+}

--- a/lib/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart
+++ b/lib/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:veta_dorada_vinculacion_mobile/core/config/environment_config.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+
+import '../../dominio/entidades/tipo_actividad.dart';
+
+/// Fuente de datos remota para obtener los tipos de actividad desde la API.
+class TipoActividadRemoteDataSource {
+  TipoActividadRemoteDataSource(this._client);
+
+  final ClienteHttp _client;
+
+  /// Realiza una solicitud GET a `/api/TipoActividad` y devuelve los tipos.
+  Future<RespuestaBase<List<TipoActividad>>> obtenerTiposActividad() async {
+    final uri =
+        Uri.parse('${EnvironmentConfig.apiBaseUrl}/api/TipoActividad');
+    final response = await _client.get(uri);
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> data =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      final codigo =
+          data['CodigoRespuesta'] as int? ?? RespuestaBase.RESPUESTA_ERROR;
+      if (codigo == RespuestaBase.RESPUESTA_CORRECTA &&
+          data['Respuesta'] is List) {
+        final tipos = (data['Respuesta'] as List<dynamic>)
+            .map((e) => TipoActividad.fromJson(e as Map<String, dynamic>))
+            .toList();
+        return RespuestaBase(codigoRespuesta: codigo, respuesta: tipos);
+      } else {
+        return RespuestaBase(
+          codigoRespuesta: codigo,
+          mensajeError:
+              data['MensajeError']?.toString() ?? 'Error al obtener tipos de actividad',
+        );
+      }
+    } else {
+      return RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
+        mensajeError:
+            'Error al obtener tipos de actividad: ${response.statusCode}',
+      );
+    }
+  }
+}

--- a/lib/features/actividad/datos/repositorios/actividad_repository_impl.dart
+++ b/lib/features/actividad/datos/repositorios/actividad_repository_impl.dart
@@ -1,0 +1,43 @@
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+
+import '../../dominio/entidades/tipo_actividad.dart';
+import '../fuentes_datos/tipo_actividad_local_data_source.dart';
+import '../fuentes_datos/tipo_actividad_remote_data_source.dart';
+
+/// Implementación del repositorio de actividades.
+class ActividadRepositoryImpl {
+  ActividadRepositoryImpl(
+      this._remoteDataSource, this._localDataSource);
+
+  final TipoActividadRemoteDataSource _remoteDataSource;
+  final TipoActividadLocalDataSource _localDataSource;
+
+  /// Sincroniza los tipos de actividad descargándolos desde la API y
+  /// almacenándolos localmente.
+  Future<void> sincronizarTiposActividad() async {
+    final respuesta = await _remoteDataSource.obtenerTiposActividad();
+    if (respuesta.codigoRespuesta == RespuestaBase.RESPUESTA_CORRECTA &&
+        respuesta.respuesta != null) {
+      await _localDataSource.reemplazarTiposActividad(respuesta.respuesta!);
+    } else {
+      await _localDataSource.reemplazarTiposActividad(const []);
+    }
+  }
+
+  /// Obtiene los tipos de actividad, intentando primero desde la API.
+  ///
+  /// Si la solicitud remota falla, devuelve los datos locales y un mensaje
+  /// de advertencia con la causa del fallo.
+  Future<({List<TipoActividad> tipos, String? advertencia})>
+      obtenerTiposActividad() async {
+    final respuesta = await _remoteDataSource.obtenerTiposActividad();
+    if (respuesta.codigoRespuesta == RespuestaBase.RESPUESTA_CORRECTA &&
+        respuesta.respuesta != null) {
+      await _localDataSource.reemplazarTiposActividad(respuesta.respuesta!);
+      return (tipos: respuesta.respuesta!, advertencia: null);
+    } else {
+      final locales = await _localDataSource.obtenerTiposActividad();
+      return (tipos: locales, advertencia: respuesta.mensajeError);
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,9 @@ import 'core/servicios/servicio_bd_local.dart';
 import 'features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart';
 import 'features/flujo_visita/datos/fuentes_datos/general_remote_data_source.dart';
 import 'features/flujo_visita/datos/repositorios/general_repository.dart';
+import 'features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart';
+import 'features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart';
+import 'features/actividad/datos/repositorios/actividad_repository_impl.dart';
 import 'router/app_router.dart';
 
 Future<void> main() async {
@@ -92,6 +95,12 @@ Future<void> _sincronizarListas(AuthNotifier authNotifier) async {
     GeneralLocalDataSource(ServicioBdLocal()),
   );
   await repo.sincronizarDatosGenerales();
+
+  final actividadRepo = ActividadRepositoryImpl(
+    TipoActividadRemoteDataSource(ClienteHttp(token: token)),
+    TipoActividadLocalDataSource(ServicioBdLocal()),
+  );
+  await actividadRepo.sincronizarTiposActividad();
 }
 
 Future<void> _clearSession(


### PR DESCRIPTION
## Summary
- add local storage table for activity types
- implement remote and local data sources for activity types
- create repository to sync and obtain activity types and trigger sync on startup

## Testing
- `flutter format lib/core/servicios/servicio_bd_local.dart lib/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart lib/features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart lib/features/actividad/datos/repositorios/actividad_repository_impl.dart lib/main.dart` *(command not found)*
- `apt-get update` *(403 Forbidden; repository not signed)*
- `flutter test` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689823d6a64c8331ba171658d8413102