### PR TITLE
feat: add activity page to visit flow

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:go_router/go_router.dart';
+
 import '../../../actividad/datos/repositorios/actividad_repository_impl.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../../actividad/dominio/entidades/tipo_actividad.dart';
@@ -118,8 +120,7 @@ class _ActividadMineraReinfoPaginaState
       zonaUTM: int.tryParse(_zonaController.text),
       descripcion: null,
     );
-    // ignore: avoid_print
-    print('Actividad creada: ${actividad.toJson()}');
+    context.push('/flujo-visita/datos-proveedor', extra: actividad);
   }
 
   @override

--- a/lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 
-import '../../../visitas/dominio/entidades/proveedor.dart';
+import '../../../actividad/dominio/entidades/actividad.dart';
 
 /// Página para registrar los datos del proveedor de mineral.
 ///
 /// Muestra un formulario para registrar la información del proveedor.
 class DatosProveedorMineralPagina extends StatefulWidget {
-  const DatosProveedorMineralPagina({super.key, required this.proveedor});
+  const DatosProveedorMineralPagina({super.key, required this.actividad});
 
-  final Proveedor proveedor;
+  final Actividad actividad;
 
   @override
   State<DatosProveedorMineralPagina> createState() =>
@@ -33,11 +33,6 @@ class _DatosProveedorMineralPaginaState
   @override
   void initState() {
     super.initState();
-    _tipoPersona = widget.proveedor.tipo.estado;
-    _nombreController.text = widget.proveedor.nombre;
-    _rucController.text = widget.proveedor.ruc;
-    _razonSocialController.text = widget.proveedor.razonSocial ?? '';
-    _representanteController.text = widget.proveedor.representanteNombre ?? '';
   }
 
   @override
@@ -66,6 +61,8 @@ class _DatosProveedorMineralPaginaState
 
   void _siguiente() {
     if (_formKey.currentState!.validate()) {
+      // ignore: avoid_print
+      print('Actividad recibida: ${widget.actividad.toJson()}');
       // Navegar al siguiente paso o guardar la información.
     }
   }

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -2,8 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../core/auth/auth_notifier.dart';
+import '../core/auth/auth_provider.dart';
+import '../core/red/cliente_http.dart';
+import '../core/servicios/servicio_bd_local.dart';
 import '../core/widgets/protected_scaffold.dart';
+import '../features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart';
+import '../features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart';
+import '../features/actividad/datos/repositorios/actividad_repository_impl.dart';
+import '../features/actividad/dominio/entidades/actividad.dart';
 import '../features/autenticacion/presentacion/paginas/login_page.dart';
+import '../features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart';
+import '../features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart';
 import '../features/visitas/presentacion/paginas/visitas_tabs_page.dart';
 
 /// Crea la configuración del enrutador principal de la aplicación.
@@ -21,6 +30,24 @@ GoRouter createRouter(AuthNotifier authNotifier) {
       GoRoute(
         path: '/login',
         builder: (context, state) => const LoginPage(),
+      ),
+      GoRoute(
+        path: '/flujo-visita/actividad-reinfo',
+        builder: (context, state) {
+          final auth = AuthProvider.of(context);
+          final repo = ActividadRepositoryImpl(
+            TipoActividadRemoteDataSource(ClienteHttp(token: auth.token!)),
+            TipoActividadLocalDataSource(ServicioBdLocal()),
+          );
+          return ActividadMineraReinfoPagina(repository: repo);
+        },
+      ),
+      GoRoute(
+        path: '/flujo-visita/datos-proveedor',
+        builder: (context, state) {
+          final actividad = state.extra! as Actividad;
+          return DatosProveedorMineralPagina(actividad: actividad);
+        },
       ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) {


### PR DESCRIPTION
## Summary
- add go_router navigation from mining activity form to next step
- accept `Actividad` in provider data page
- register visit flow routes in app router

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68982762ba508331b1b8660c4157b2d9