### PR TITLE
test: add actividad tests

### DIFF
--- a/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/servicios/servicio_bd_local.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/repositorios/actividad_repository_impl.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/dominio/entidades/tipo_actividad.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart';
+
+class _FakeRepository extends ActividadRepositoryImpl {
+  _FakeRepository(this._tipos)
+      : super(
+          TipoActividadRemoteDataSource(
+            ClienteHttp(token: '', inner: MockClient((_) async => http.Response('', 500))),
+          ),
+          TipoActividadLocalDataSource(ServicioBdLocal()),
+        );
+
+  final List<TipoActividad> _tipos;
+
+  @override
+  Future<({List<TipoActividad> tipos, String? advertencia})>
+      obtenerTiposActividad() async {
+    return (tipos: _tipos, advertencia: null);
+  }
+}
+
+void main() {
+  testWidgets('carga inicial de combos', (tester) async {
+    final repo = _FakeRepository([
+      TipoActividad(id: 1, descripcion: 'Exploración'),
+      TipoActividad(id: 2, descripcion: 'Beneficio'),
+    ]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: ActividadMineraReinfoPagina(repository: repo),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<TipoActividad>));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Exploración'), findsOneWidget);
+    expect(find.text('Beneficio'), findsOneWidget);
+  });
+
+  testWidgets('cambia combo secundario al seleccionar otro tipo', (tester) async {
+    final repo = _FakeRepository([
+      TipoActividad(id: 1, descripcion: 'Explotación'),
+      TipoActividad(id: 2, descripcion: 'Beneficio'),
+    ]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: ActividadMineraReinfoPagina(repository: repo),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<TipoActividad>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Explotación').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    expect(find.text('Aluvial'), findsOneWidget);
+    expect(find.text('Filoniano'), findsOneWidget);
+    await tester.tap(find.text('Aluvial').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<TipoActividad>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Beneficio').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    expect(find.text('Gravimétrico'), findsOneWidget);
+    expect(find.text('Lixiviación'), findsOneWidget);
+    expect(find.text('Aluvial'), findsNothing);
+  });
+}
+

--- a/test/features/actividad/actividad_repository_impl_test.dart
+++ b/test/features/actividad/actividad_repository_impl_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/repositorios/actividad_repository_impl.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/dominio/entidades/tipo_actividad.dart';
+
+class _FakeRemote implements TipoActividadRemoteDataSource {
+  _FakeRemote(this.respuesta);
+
+  final RespuestaBase<List<TipoActividad>> respuesta;
+
+  @override
+  Future<RespuestaBase<List<TipoActividad>>> obtenerTiposActividad() async {
+    return respuesta;
+  }
+}
+
+class _FakeLocal implements TipoActividadLocalDataSource {
+  List<TipoActividad> almacenados = [];
+
+  @override
+  Future<List<TipoActividad>> obtenerTiposActividad() async {
+    return almacenados;
+  }
+
+  @override
+  Future<void> reemplazarTiposActividad(List<TipoActividad> tipos) async {
+    almacenados = List.from(tipos);
+  }
+}
+
+void main() {
+  group('ActividadRepositoryImpl', () {
+    test('sincronizarTiposActividad guarda los datos obtenidos', () async {
+      final remoto = _FakeRemote(RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_CORRECTA,
+        respuesta: [TipoActividad(id: 1, descripcion: 'Exploración')],
+      ));
+      final local = _FakeLocal();
+      final repo = ActividadRepositoryImpl(remoto, local);
+
+      await repo.sincronizarTiposActividad();
+
+      expect(local.almacenados.length, 1);
+      expect(local.almacenados.first.descripcion, 'Exploración');
+    });
+
+    test('sincronizarTiposActividad limpia datos cuando hay error', () async {
+      final remoto = _FakeRemote(RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
+        mensajeError: 'fallo',
+      ));
+      final local = _FakeLocal();
+      local.almacenados = [TipoActividad(id: 1, descripcion: 'A')];
+      final repo = ActividadRepositoryImpl(remoto, local);
+
+      await repo.sincronizarTiposActividad();
+
+      expect(local.almacenados, isEmpty);
+    });
+
+    test('obtenerTiposActividad retorna datos remotos y sincroniza locales', () async {
+      final remoto = _FakeRemote(RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_CORRECTA,
+        respuesta: [TipoActividad(id: 1, descripcion: 'Exploración')],
+      ));
+      final local = _FakeLocal();
+      final repo = ActividadRepositoryImpl(remoto, local);
+
+      final result = await repo.obtenerTiposActividad();
+
+      expect(result.advertencia, isNull);
+      expect(result.tipos.length, 1);
+      expect(local.almacenados.length, 1);
+    });
+
+    test('obtenerTiposActividad retorna locales cuando remoto falla', () async {
+      final remoto = _FakeRemote(RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
+        mensajeError: 'error remoto',
+      ));
+      final local = _FakeLocal();
+      local.almacenados = [TipoActividad(id: 2, descripcion: 'Beneficio')];
+      final repo = ActividadRepositoryImpl(remoto, local);
+
+      final result = await repo.obtenerTiposActividad();
+
+      expect(result.advertencia, 'error remoto');
+      expect(result.tipos.first.descripcion, 'Beneficio');
+    });
+  });
+}
+

--- a/test/features/actividad/tipo_actividad_remote_data_source_test.dart
+++ b/test/features/actividad/tipo_actividad_remote_data_source_test.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/dominio/entidades/tipo_actividad.dart';
+
+void main() {
+  group('TipoActividadRemoteDataSource', () {
+    test('convierte respuesta JSON a lista de TipoActividad', () async {
+      final mockClient = MockClient((request) async {
+        final body = jsonEncode({
+          'CodigoRespuesta': RespuestaBase.RESPUESTA_CORRECTA,
+          'Respuesta': [
+            {'id': 1, 'descripcion': 'Exploración'},
+            {'id': 2, 'descripcion': 'Beneficio'},
+          ],
+        });
+        return http.Response(body, 200);
+      });
+      final cliente = ClienteHttp(token: '', inner: mockClient);
+      final dataSource = TipoActividadRemoteDataSource(cliente);
+
+      final respuesta = await dataSource.obtenerTiposActividad();
+
+      expect(respuesta.codigoRespuesta, RespuestaBase.RESPUESTA_CORRECTA);
+      expect(respuesta.respuesta, isA<List<TipoActividad>>());
+      expect(respuesta.respuesta!.length, 2);
+      expect(respuesta.respuesta!.first.descripcion, 'Exploración');
+    });
+
+    test('devuelve error cuando el servidor responde con código no 200', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('Error', 500);
+      });
+      final cliente = ClienteHttp(token: '', inner: mockClient);
+      final dataSource = TipoActividadRemoteDataSource(cliente);
+
+      final respuesta = await dataSource.obtenerTiposActividad();
+
+      expect(respuesta.codigoRespuesta, RespuestaBase.RESPUESTA_ERROR);
+      expect(respuesta.respuesta, isNull);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add tests for TipoActividadRemoteDataSource json parsing
- cover ActividadRepositoryImpl sync logic and fallback
- add widget tests for ActividadMineraReinfoPagina combos

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `apt-get update && apt-get install -y flutter` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898290cd2688331a2d068994e09d4df