### PR TITLE
Add IGAFOM activity page and routing

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+
+import 'package:go_router/go_router.dart';
+
+import '../../../actividad/datos/repositorios/actividad_repository_impl.dart';
+import '../../../actividad/dominio/entidades/actividad.dart';
+import '../../../actividad/dominio/entidades/tipo_actividad.dart';
+import '../../../actividad/dominio/enums/reinfo.dart';
+
+typedef Origen = Reinfo;
+
+/// Página para registrar una actividad minera de origen IGAFOM.
+///
+/// Carga los tipos de actividad desde el [ActividadRepositoryImpl] y permite
+/// seleccionar un tipo y sub tipo además de registrar información adicional
+/// como coordenadas y ubicación política.
+class ActividadMineraIgafomPagina extends StatefulWidget {
+  const ActividadMineraIgafomPagina({
+    super.key,
+    required this.repository,
+  });
+
+  /// Repositorio usado para obtener los tipos de actividad.
+  final ActividadRepositoryImpl repository;
+
+  @override
+  State<ActividadMineraIgafomPagina> createState() =>
+      _ActividadMineraIgafomPaginaState();
+}
+
+class _ActividadMineraIgafomPaginaState
+    extends State<ActividadMineraIgafomPagina> {
+  final _formKey = GlobalKey<FormState>();
+
+  List<TipoActividad> _tipos = [];
+  TipoActividad? _tipoSeleccionado;
+  String? _subTipoSeleccionado;
+  List<String> _subTiposDisponibles = [];
+  String _labelSubTipo = 'Sub Tipo';
+
+  final Map<int, List<String>> _mapaSubTipos = {
+    // Opciones de ejemplo para los sub tipos dependiendo del tipo.
+    1: ['Aluvial', 'Filoniano'],
+    2: ['Gravimétrico', 'Lixiviación'],
+  };
+
+  final TextEditingController _sistemaController = TextEditingController();
+  final TextEditingController _zonaController = TextEditingController();
+  final TextEditingController _comp01EsteController = TextEditingController();
+  final TextEditingController _comp01NorteController = TextEditingController();
+  final TextEditingController _comp02EsteController = TextEditingController();
+  final TextEditingController _comp02NorteController = TextEditingController();
+  final TextEditingController _departamentoController = TextEditingController();
+  final TextEditingController _provinciaController = TextEditingController();
+  final TextEditingController _distritoController = TextEditingController();
+  final TextEditingController _derechoMineroController =
+      TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _cargarTipos();
+  }
+
+  @override
+  void dispose() {
+    _sistemaController.dispose();
+    _zonaController.dispose();
+    _comp01EsteController.dispose();
+    _comp01NorteController.dispose();
+    _comp02EsteController.dispose();
+    _comp02NorteController.dispose();
+    _departamentoController.dispose();
+    _provinciaController.dispose();
+    _distritoController.dispose();
+    _derechoMineroController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _cargarTipos() async {
+    final resultado = await widget.repository.obtenerTiposActividad();
+    setState(() {
+      _tipos = resultado.tipos;
+    });
+  }
+
+  void _onTipoChanged(TipoActividad? tipo) {
+    setState(() {
+      _tipoSeleccionado = tipo;
+      _subTipoSeleccionado = null;
+      _subTiposDisponibles = _mapaSubTipos[tipo?.id] ?? [];
+      if (tipo != null) {
+        final desc = tipo.descripcion.toLowerCase();
+        if (desc.contains('beneficio')) {
+          _labelSubTipo = 'Tipo de Beneficio';
+        } else if (desc.contains('explot')) {
+          _labelSubTipo = 'Tipo de Explotación';
+        } else {
+          _labelSubTipo = 'Sub Tipo';
+        }
+      } else {
+        _labelSubTipo = 'Sub Tipo';
+      }
+    });
+  }
+
+  void _guardar() {
+    if (!_formKey.currentState!.validate() ||
+        _tipoSeleccionado == null ||
+        _subTipoSeleccionado == null) {
+      return;
+    }
+    final actividad = Actividad(
+      id: '',
+      origen: Origen.igafom,
+      idTipoActividad: _tipoSeleccionado!.id,
+      idSubTipoActividad:
+          _subTiposDisponibles.indexOf(_subTipoSeleccionado!) + 1,
+      sistemaUTM: int.tryParse(_sistemaController.text) ?? 0,
+      utmEste: double.tryParse(_comp01EsteController.text) ?? 0,
+      utmNorte: double.tryParse(_comp01NorteController.text) ?? 0,
+      zonaUTM: int.tryParse(_zonaController.text),
+      descripcion: null,
+    );
+    context.push('/flujo-visita/datos-proveedor', extra: actividad);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+          title: const Text(
+              'Actividad Minera Declarada por el Proveedor de Mineral en el IGAFOM')),
+      body: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              DropdownButtonFormField<TipoActividad>(
+                decoration: const InputDecoration(
+                  labelText: 'Tipo de actividad',
+                ),
+                value: _tipoSeleccionado,
+                items: _tipos
+                    .map((e) => DropdownMenuItem(
+                          value: e,
+                          child: Text(e.descripcion),
+                        ))
+                    .toList(),
+                onChanged: _onTipoChanged,
+                validator: (value) =>
+                    value == null ? 'Seleccione el tipo de actividad' : null,
+              ),
+              const SizedBox(height: 16),
+              if (_subTiposDisponibles.isNotEmpty)
+                DropdownButtonFormField<String>(
+                  decoration: InputDecoration(labelText: _labelSubTipo),
+                  value: _subTipoSeleccionado,
+                  items: _subTiposDisponibles
+                      .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                      .toList(),
+                  onChanged: (value) =>
+                      setState(() => _subTipoSeleccionado = value),
+                  validator: (value) =>
+                      value == null ? 'Seleccione una opción' : null,
+                ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _sistemaController,
+                decoration:
+                    const InputDecoration(labelText: 'Sistema UTM'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _zonaController,
+                decoration: const InputDecoration(labelText: 'Zona'),
+              ),
+              const SizedBox(height: 16),
+              const Text('Coordenadas Componente 01'),
+              TextFormField(
+                controller: _comp01EsteController,
+                decoration: const InputDecoration(labelText: 'Este'),
+              ),
+              TextFormField(
+                controller: _comp01NorteController,
+                decoration: const InputDecoration(labelText: 'Norte'),
+              ),
+              const SizedBox(height: 16),
+              const Text('Coordenadas Componente 02'),
+              TextFormField(
+                controller: _comp02EsteController,
+                decoration: const InputDecoration(labelText: 'Este'),
+              ),
+              TextFormField(
+                controller: _comp02NorteController,
+                decoration: const InputDecoration(labelText: 'Norte'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _departamentoController,
+                decoration:
+                    const InputDecoration(labelText: 'Departamento'),
+              ),
+              TextFormField(
+                controller: _provinciaController,
+                decoration: const InputDecoration(labelText: 'Provincia'),
+              ),
+              TextFormField(
+                controller: _distritoController,
+                decoration: const InputDecoration(labelText: 'Distrito'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _derechoMineroController,
+                decoration:
+                    const InputDecoration(labelText: 'Derecho minero'),
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _guardar,
+                  child: const Text('Guardar'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -12,6 +12,7 @@ import '../features/actividad/datos/repositorios/actividad_repository_impl.dart'
 import '../features/actividad/dominio/entidades/actividad.dart';
 import '../features/autenticacion/presentacion/paginas/login_page.dart';
 import '../features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart';
+import '../features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart';
 import '../features/visitas/presentacion/paginas/visitas_tabs_page.dart';
 
@@ -40,6 +41,17 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             TipoActividadLocalDataSource(ServicioBdLocal()),
           );
           return ActividadMineraReinfoPagina(repository: repo);
+        },
+      ),
+      GoRoute(
+        path: '/flujo-visita/actividad-igafom',
+        builder: (context, state) {
+          final auth = AuthProvider.of(context);
+          final repo = ActividadRepositoryImpl(
+            TipoActividadRemoteDataSource(ClienteHttp(token: auth.token!)),
+            TipoActividadLocalDataSource(ServicioBdLocal()),
+          );
+          return ActividadMineraIgafomPagina(repository: repo);
         },
       ),
       GoRoute(

--- a/test/features/actividad/actividad_minera_igafom_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_igafom_pagina_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/servicios/servicio_bd_local.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/datos/repositorios/actividad_repository_impl.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/dominio/entidades/tipo_actividad.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart';
+
+class _FakeRepository extends ActividadRepositoryImpl {
+  _FakeRepository(this._tipos)
+      : super(
+          TipoActividadRemoteDataSource(
+            ClienteHttp(token: '', inner: MockClient((_) async => http.Response('', 500))),
+          ),
+          TipoActividadLocalDataSource(ServicioBdLocal()),
+        );
+
+  final List<TipoActividad> _tipos;
+
+  @override
+  Future<({List<TipoActividad> tipos, String? advertencia})>
+      obtenerTiposActividad() async {
+    return (tipos: _tipos, advertencia: null);
+  }
+}
+
+void main() {
+  testWidgets('carga inicial de combos', (tester) async {
+    final repo = _FakeRepository([
+      TipoActividad(id: 1, descripcion: 'Exploración'),
+      TipoActividad(id: 2, descripcion: 'Beneficio'),
+    ]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: ActividadMineraIgafomPagina(repository: repo),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<TipoActividad>));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Exploración'), findsOneWidget);
+    expect(find.text('Beneficio'), findsOneWidget);
+  });
+
+  testWidgets('cambia combo secundario al seleccionar otro tipo', (tester) async {
+    final repo = _FakeRepository([
+      TipoActividad(id: 1, descripcion: 'Explotación'),
+      TipoActividad(id: 2, descripcion: 'Beneficio'),
+    ]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: ActividadMineraIgafomPagina(repository: repo),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<TipoActividad>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Explotación').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    expect(find.text('Aluvial'), findsOneWidget);
+    expect(find.text('Filoniano'), findsOneWidget);
+    await tester.tap(find.text('Aluvial').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<TipoActividad>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Beneficio').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    expect(find.text('Gravimétrico'), findsOneWidget);
+    expect(find.text('Lixiviación'), findsOneWidget);
+    expect(find.text('Aluvial'), findsNothing);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add IGAFOM activity form page using Origen.igafom
- register /flujo-visita/actividad-igafom route
- copy tests for new IGAFOM activity page

## Testing
- `dart format lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart lib/router/app_router.dart test/features/actividad/actividad_minera_igafom_pagina_test.dart` *(fail: command not found)*
- `flutter test test/features/actividad/actividad_minera_igafom_pagina_test.dart` *(fail: command not found)*
- `apt-get update` *(fail: repository not signed)*
- `apt-get install -y flutter` *(fail: Unable to locate package flutter)*
- `apt-get install -y dart` *(fail: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689903bece508331ba00d1d668cdb763