### PR TITLE
Add description step after verifying activity

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
@@ -120,7 +120,8 @@ class _ActividadMineraVerificadaPaginaState
       zonaUTM: int.tryParse(_zonaController.text),
       descripcion: null,
     );
-    context.push('/flujo-visita/datos-proveedor', extra: actividad);
+    context.push('/flujo-visita/descripcion-actividad-verificada',
+        extra: actividad);
   }
 
   @override

--- a/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
@@ -1,12 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../actividad/dominio/entidades/actividad.dart';
+
 /// Página para describir la actividad minera verificada.
 ///
 /// Muestra un formulario con varias secciones de información
 /// complementaria respecto a la actividad verificada.
 class DescripcionActividadMineraVerificadaPagina extends StatefulWidget {
-  const DescripcionActividadMineraVerificadaPagina({super.key});
+  const DescripcionActividadMineraVerificadaPagina({
+    super.key,
+    required this.actividad,
+  });
+
+  final Actividad actividad;
 
   @override
   State<DescripcionActividadMineraVerificadaPagina> createState() =>
@@ -37,7 +44,7 @@ class _DescripcionActividadMineraVerificadaPaginaState
 
   void _siguiente() {
     if (_formKey.currentState!.validate()) {
-      context.push('/flujo-visita/paso6');
+      context.push('/flujo-visita/datos-proveedor', extra: widget.actividad);
     }
   }
 

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -14,6 +14,7 @@ import '../features/autenticacion/presentacion/paginas/login_page.dart';
 import '../features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart';
+import '../features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart';
 import '../features/visitas/presentacion/paginas/visitas_tabs_page.dart';
 
@@ -53,6 +54,15 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             TipoActividadLocalDataSource(ServicioBdLocal()),
           );
           return ActividadMineraVerificadaPagina(repository: repo);
+        },
+      ),
+      GoRoute(
+        path: '/flujo-visita/descripcion-actividad-verificada',
+        builder: (context, state) {
+          final actividad = state.extra! as Actividad;
+          return DescripcionActividadMineraVerificadaPagina(
+            actividad: actividad,
+          );
         },
       ),
       GoRoute(


### PR DESCRIPTION
## Summary
- add route for verified activity description and link navigation
- send verified activity to description step before provider data
- keep step progress consistent

## Testing
- `dart format lib/router/app_router.dart lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68991eb549e483319129f5ca59e94d6a