### PR TITLE
feat: add description activity entity

### DIFF
--- a/lib/features/flujo_visita/datos/repositorios/flow_repository_impl.dart
+++ b/lib/features/flujo_visita/datos/repositorios/flow_repository_impl.dart
@@ -1,0 +1,20 @@
+import '../../dominio/entidades/descripcion_actividad_verificada.dart';
+import '../../dominio/repositorios/flow_repository.dart';
+
+/// Implementación en memoria de [FlowRepository].
+class FlowRepositoryImpl implements FlowRepository {
+  DescripcionActividadVerificada? _descripcion;
+
+  @override
+  Future<void> guardarDescripcionActividadVerificada(
+      DescripcionActividadVerificada descripcion) async {
+    _descripcion = descripcion;
+  }
+
+  @override
+  Future<DescripcionActividadVerificada?>
+      obtenerDescripcionActividadVerificada() async {
+    return _descripcion;
+  }
+}
+

--- a/lib/features/flujo_visita/dominio/casos_uso/descripcion_actividad_verificada.dart
+++ b/lib/features/flujo_visita/dominio/casos_uso/descripcion_actividad_verificada.dart
@@ -1,0 +1,23 @@
+import '../entidades/descripcion_actividad_verificada.dart';
+import '../repositorios/flow_repository.dart';
+
+/// Caso de uso para guardar la descripción de la actividad verificada.
+class GuardarDescripcionActividadVerificada {
+  GuardarDescripcionActividadVerificada(this._repositorio);
+
+  final FlowRepository _repositorio;
+
+  Future<void> call(DescripcionActividadVerificada descripcion) =>
+      _repositorio.guardarDescripcionActividadVerificada(descripcion);
+}
+
+/// Caso de uso para obtener la descripción de la actividad verificada.
+class ObtenerDescripcionActividadVerificada {
+  ObtenerDescripcionActividadVerificada(this._repositorio);
+
+  final FlowRepository _repositorio;
+
+  Future<DescripcionActividadVerificada?> call() =>
+      _repositorio.obtenerDescripcionActividadVerificada();
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/descripcion_actividad_verificada.dart
+++ b/lib/features/flujo_visita/dominio/entidades/descripcion_actividad_verificada.dart
@@ -1,0 +1,52 @@
+/// Describe la actividad minera verificada durante la visita.
+class DescripcionActividadVerificada {
+  /// Coordenadas y ubicación geográfica y política.
+  final String coordenadas;
+
+  /// Zona de la labor minera.
+  final String zona;
+
+  /// Descripción de la actividad minera verificada.
+  final String actividad;
+
+  /// Equipos y maquinaria observados.
+  final String equipos;
+
+  /// Trabajadores presentes en la actividad.
+  final String trabajadores;
+
+  /// Condiciones laborales y de seguridad observadas.
+  final String condicionesLaborales;
+
+  /// Crea una instancia de [DescripcionActividadVerificada].
+  const DescripcionActividadVerificada({
+    required this.coordenadas,
+    required this.zona,
+    required this.actividad,
+    required this.equipos,
+    required this.trabajadores,
+    required this.condicionesLaborales,
+  });
+
+  /// Crea una [DescripcionActividadVerificada] a partir de un mapa JSON.
+  factory DescripcionActividadVerificada.fromJson(Map<String, dynamic> json) =>
+      DescripcionActividadVerificada(
+        coordenadas: json['coordenadas'] as String,
+        zona: json['zona'] as String,
+        actividad: json['actividad'] as String,
+        equipos: json['equipos'] as String,
+        trabajadores: json['trabajadores'] as String,
+        condicionesLaborales: json['condicionesLaborales'] as String,
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'coordenadas': coordenadas,
+        'zona': zona,
+        'actividad': actividad,
+        'equipos': equipos,
+        'trabajadores': trabajadores,
+        'condicionesLaborales': condicionesLaborales,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/repositorios/flow_repository.dart
+++ b/lib/features/flujo_visita/dominio/repositorios/flow_repository.dart
@@ -1,0 +1,13 @@
+import '../entidades/descripcion_actividad_verificada.dart';
+
+/// Repositorio para manejar los datos del flujo de visita.
+abstract class FlowRepository {
+  /// Guarda la descripción de la actividad verificada.
+  Future<void> guardarDescripcionActividadVerificada(
+      DescripcionActividadVerificada descripcion);
+
+  /// Recupera la descripción de la actividad verificada almacenada.
+  Future<DescripcionActividadVerificada?>
+      obtenerDescripcionActividadVerificada();
+}
+


### PR DESCRIPTION
## Summary
- add DescripcionActividadVerificada entity with JSON helpers
- extend FlowRepository and implement in-memory storage
- provide use cases to save and retrieve the description

## Testing
- `dart format lib/features/flujo_visita/dominio/entidades/descripcion_actividad_verificada.dart lib/features/flujo_visita/dominio/repositorios/flow_repository.dart lib/features/flujo_visita/datos/repositorios/flow_repository_impl.dart lib/features/flujo_visita/dominio/casos_uso/descripcion_actividad_verificada.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899203f74088331bbb511e88e421501