### PR TITLE
feat: add photographic verification step

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart
@@ -79,6 +79,10 @@ class _DatosProveedorMineralPaginaState
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              const Center(child: Text('7 de 9')),
+              const SizedBox(height: 8),
+              const LinearProgressIndicator(value: 7 / 9),
+              const SizedBox(height: 24),
               DropdownButtonFormField<String>(
                 value: _tipoPersona,
                 decoration: const InputDecoration(labelText: 'Tipo de persona'),

--- a/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
@@ -44,7 +44,8 @@ class _DescripcionActividadMineraVerificadaPaginaState
 
   void _siguiente() {
     if (_formKey.currentState!.validate()) {
-      context.push('/flujo-visita/datos-proveedor', extra: widget.actividad);
+      context.push('/flujo-visita/registro-fotografico-verificacion',
+          extra: widget.actividad);
     }
   }
 

--- a/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
@@ -1,0 +1,180 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+import '../../../actividad/dominio/entidades/actividad.dart';
+
+/// Página para registrar fotografías durante la verificación.
+///
+/// Permite capturar imágenes, agregar título y descripción y
+/// guarda la información junto a la ubicación y fecha de captura.
+class RegistroFotograficoVerificacionPagina extends StatefulWidget {
+  const RegistroFotograficoVerificacionPagina({
+    super.key,
+    required this.actividad,
+  });
+
+  final Actividad actividad;
+
+  @override
+  State<RegistroFotograficoVerificacionPagina> createState() =>
+      _RegistroFotograficoVerificacionPaginaState();
+}
+
+class _RegistroFotograficoVerificacionPaginaState
+    extends State<RegistroFotograficoVerificacionPagina> {
+  final ImagePicker _picker = ImagePicker();
+  final List<_FotoRegistro> _fotos = [];
+
+  Future<void> _agregarFoto() async {
+    final XFile? image = await _picker.pickImage(source: ImageSource.camera);
+    if (image == null) return;
+
+    final position = await Geolocator.getCurrentPosition();
+    final now = DateTime.now();
+    final directory = await getApplicationDocumentsDirectory();
+    final newPath = p.join(directory.path, '${now.millisecondsSinceEpoch}.jpg');
+    final saved = await File(image.path).copy(newPath);
+
+    final tituloController = TextEditingController();
+    final descripcionController = TextEditingController();
+
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Detalles de la foto'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Image.file(
+                File(saved.path),
+                height: 100,
+                fit: BoxFit.cover,
+              ),
+              TextFormField(
+                controller: tituloController,
+                decoration: const InputDecoration(labelText: 'Título'),
+              ),
+              TextFormField(
+                controller: descripcionController,
+                decoration: const InputDecoration(labelText: 'Descripción'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                saved.deleteSync();
+                Navigator.of(context).pop();
+              },
+              child: const Text('Cancelar'),
+            ),
+            TextButton(
+              onPressed: () {
+                setState(() {
+                  _fotos.add(
+                    _FotoRegistro(
+                      path: saved.path,
+                      titulo: tituloController.text,
+                      descripcion: descripcionController.text,
+                      fecha: now,
+                      latitud: position.latitude,
+                      longitud: position.longitude,
+                    ),
+                  );
+                });
+                Navigator.of(context).pop();
+              },
+              child: const Text('Guardar'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _siguiente() {
+    context.push('/flujo-visita/datos-proveedor', extra: widget.actividad);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Registro Fotográfico')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            const Center(child: Text('6 de 9')),
+            const SizedBox(height: 8),
+            const LinearProgressIndicator(value: 6 / 9),
+            const SizedBox(height: 24),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: ElevatedButton.icon(
+                onPressed: _agregarFoto,
+                icon: const Icon(Icons.add_a_photo),
+                label: const Text('Añadir foto'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: _fotos.isEmpty
+                  ? const Center(child: Text('Sin fotos registradas'))
+                  : ListView.builder(
+                      itemCount: _fotos.length,
+                      itemBuilder: (context, index) {
+                        final foto = _fotos[index];
+                        return ListTile(
+                          leading: Image.file(
+                            File(foto.path),
+                            width: 56,
+                            height: 56,
+                            fit: BoxFit.cover,
+                          ),
+                          title: Text(
+                              foto.titulo.isEmpty ? 'Sin título' : foto.titulo),
+                          subtitle: Text(foto.descripcion.isEmpty
+                              ? 'Sin descripción'
+                              : foto.descripcion),
+                        );
+                      },
+                    ),
+            ),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _fotos.isNotEmpty ? _siguiente : null,
+                child: const Text('Siguiente'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FotoRegistro {
+  _FotoRegistro({
+    required this.path,
+    required this.titulo,
+    required this.descripcion,
+    required this.fecha,
+    required this.latitud,
+    required this.longitud,
+  });
+
+  final String path;
+  final String titulo;
+  final String descripcion;
+  final DateTime fecha;
+  final double latitud;
+  final double longitud;
+}

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -16,6 +16,7 @@ import '../features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pa
 import '../features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart';
+import '../features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart';
 import '../features/visitas/presentacion/paginas/visitas_tabs_page.dart';
 
 /// Crea la configuración del enrutador principal de la aplicación.
@@ -74,6 +75,13 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             TipoActividadLocalDataSource(ServicioBdLocal()),
           );
           return ActividadMineraIgafomPagina(repository: repo);
+        },
+      ),
+      GoRoute(
+        path: '/flujo-visita/registro-fotografico-verificacion',
+        builder: (context, state) {
+          final actividad = state.extra! as Actividad;
+          return RegistroFotograficoVerificacionPagina(actividad: actividad);
         },
       ),
       GoRoute(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,9 @@ dependencies:
   sqflite: ^2.3.0+1
   path: ^1.9.0
   bloc: ^8.1.0
+  image_picker: ^1.0.4
+  geolocator: ^10.1.0
+  path_provider: ^2.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add photographic registration page with camera capture and metadata
- route photo page into visit flow and update progress steps
- include camera, location and storage dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689925440da08331a3bd76eecfd22371