### PR TITLE
feat: registrar fotos de verificación en flujo de visita

### DIFF
--- a/lib/features/flujo_visita/datos/repositorios/flow_repository_impl.dart
+++ b/lib/features/flujo_visita/datos/repositorios/flow_repository_impl.dart
@@ -1,9 +1,11 @@
 import '../../dominio/entidades/descripcion_actividad_verificada.dart';
+import '../../dominio/entidades/registro_fotografico.dart';
 import '../../dominio/repositorios/flow_repository.dart';
 
 /// Implementación en memoria de [FlowRepository].
 class FlowRepositoryImpl implements FlowRepository {
   DescripcionActividadVerificada? _descripcion;
+  final List<RegistroFotografico> _fotos = [];
 
   @override
   Future<void> guardarDescripcionActividadVerificada(
@@ -15,6 +17,16 @@ class FlowRepositoryImpl implements FlowRepository {
   Future<DescripcionActividadVerificada?>
       obtenerDescripcionActividadVerificada() async {
     return _descripcion;
+  }
+
+  @override
+  Future<void> agregarFotoVerificacion(RegistroFotografico foto) async {
+    _fotos.add(foto);
+  }
+
+  @override
+  Future<List<RegistroFotografico>> obtenerFotosVerificacion() async {
+    return List.unmodifiable(_fotos);
   }
 }
 

--- a/lib/features/flujo_visita/dominio/casos_uso/registro_fotografico.dart
+++ b/lib/features/flujo_visita/dominio/casos_uso/registro_fotografico.dart
@@ -1,0 +1,23 @@
+import '../entidades/registro_fotografico.dart';
+import '../repositorios/flow_repository.dart';
+
+/// Caso de uso para agregar un registro fotográfico de la verificación.
+class AgregarFotoVerificacion {
+  AgregarFotoVerificacion(this._repositorio);
+
+  final FlowRepository _repositorio;
+
+  Future<void> call(RegistroFotografico foto) =>
+      _repositorio.agregarFotoVerificacion(foto);
+}
+
+/// Caso de uso para obtener todos los registros fotográficos agregados.
+class ObtenerFotosVerificacion {
+  ObtenerFotosVerificacion(this._repositorio);
+
+  final FlowRepository _repositorio;
+
+  Future<List<RegistroFotografico>> call() =>
+      _repositorio.obtenerFotosVerificacion();
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/registro_fotografico.dart
+++ b/lib/features/flujo_visita/dominio/entidades/registro_fotografico.dart
@@ -1,0 +1,52 @@
+/// Representa un registro fotográfico tomado durante la verificación de la visita.
+class RegistroFotografico {
+  /// Ruta local donde se encuentra almacenada la fotografía.
+  final String path;
+
+  /// Título que describe el contenido de la imagen.
+  final String titulo;
+
+  /// Descripción detallada de lo observado en la fotografía.
+  final String descripcion;
+
+  /// Fecha y hora en que se tomó la fotografía.
+  final DateTime fecha;
+
+  /// Latitud de la ubicación donde se capturó la fotografía.
+  final double latitud;
+
+  /// Longitud de la ubicación donde se capturó la fotografía.
+  final double longitud;
+
+  /// Crea una instancia de [RegistroFotografico].
+  const RegistroFotografico({
+    required this.path,
+    required this.titulo,
+    required this.descripcion,
+    required this.fecha,
+    required this.latitud,
+    required this.longitud,
+  });
+
+  /// Crea un [RegistroFotografico] a partir de un mapa JSON.
+  factory RegistroFotografico.fromJson(Map<String, dynamic> json) =>
+      RegistroFotografico(
+        path: json['path'] as String,
+        titulo: json['titulo'] as String,
+        descripcion: json['descripcion'] as String,
+        fecha: DateTime.parse(json['fecha'] as String),
+        latitud: (json['latitud'] as num).toDouble(),
+        longitud: (json['longitud'] as num).toDouble(),
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'path': path,
+        'titulo': titulo,
+        'descripcion': descripcion,
+        'fecha': fecha.toIso8601String(),
+        'latitud': latitud,
+        'longitud': longitud,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/repositorios/flow_repository.dart
+++ b/lib/features/flujo_visita/dominio/repositorios/flow_repository.dart
@@ -1,4 +1,5 @@
 import '../entidades/descripcion_actividad_verificada.dart';
+import '../entidades/registro_fotografico.dart';
 
 /// Repositorio para manejar los datos del flujo de visita.
 abstract class FlowRepository {
@@ -9,5 +10,11 @@ abstract class FlowRepository {
   /// Recupera la descripción de la actividad verificada almacenada.
   Future<DescripcionActividadVerificada?>
       obtenerDescripcionActividadVerificada();
+
+  /// Agrega un registro fotográfico de la verificación.
+  Future<void> agregarFotoVerificacion(RegistroFotografico foto);
+
+  /// Obtiene la lista de registros fotográficos agregados.
+  Future<List<RegistroFotografico>> obtenerFotosVerificacion();
 }
 


### PR DESCRIPTION
## Summary
- add `RegistroFotografico` entity
- extend flow repository with photo verification methods
- add use cases to store and retrieve verification photos

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689927261b608331a1bb95fb4e3c5ee7