### PR TITLE
Añade ruta a registro fotográfico previo a datos del proveedor

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
@@ -44,7 +44,7 @@ class _DescripcionActividadMineraVerificadaPaginaState
 
   void _siguiente() {
     if (_formKey.currentState!.validate()) {
-      context.push('/flujo-visita/registro-fotografico-verificacion',
+      context.push('/flujo-visita/registro-fotografico',
           extra: widget.actividad);
     }
   }

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -78,7 +78,7 @@ GoRouter createRouter(AuthNotifier authNotifier) {
         },
       ),
       GoRoute(
-        path: '/flujo-visita/registro-fotografico-verificacion',
+        path: '/flujo-visita/registro-fotografico',
         builder: (context, state) {
           final actividad = state.extra! as Actividad;
           return RegistroFotograficoVerificacionPagina(actividad: actividad);


### PR DESCRIPTION
## Summary
- Corrige flujo de descripción de actividad verificada para avanzar a registro fotográfico
- Expone nueva ruta `/flujo-visita/registro-fotografico` en el enrutador

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68992d4179b48331905b4a893a9a3501