### PR TITLE
feat: add photo record item widget

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
@@ -8,6 +8,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 
 import '../../../actividad/dominio/entidades/actividad.dart';
+import '../widgets/foto_registro_item.dart';
 
 /// Página para registrar fotografías durante la verificación.
 ///
@@ -99,6 +100,15 @@ class _RegistroFotograficoVerificacionPaginaState
     );
   }
 
+  void _eliminarFoto(int index) {
+    final foto = _fotos.removeAt(index);
+    final file = File(foto.path);
+    if (file.existsSync()) {
+      file.deleteSync();
+    }
+    setState(() {});
+  }
+
   void _siguiente() {
     context.push('/flujo-visita/datos-proveedor', extra: widget.actividad);
   }
@@ -131,18 +141,14 @@ class _RegistroFotograficoVerificacionPaginaState
                       itemCount: _fotos.length,
                       itemBuilder: (context, index) {
                         final foto = _fotos[index];
-                        return ListTile(
-                          leading: Image.file(
-                            File(foto.path),
-                            width: 56,
-                            height: 56,
-                            fit: BoxFit.cover,
-                          ),
-                          title: Text(
-                              foto.titulo.isEmpty ? 'Sin título' : foto.titulo),
-                          subtitle: Text(foto.descripcion.isEmpty
-                              ? 'Sin descripción'
-                              : foto.descripcion),
+                        return FotoRegistroItem(
+                          path: foto.path,
+                          titulo: foto.titulo,
+                          descripcion: foto.descripcion,
+                          fecha: foto.fecha,
+                          latitud: foto.latitud,
+                          longitud: foto.longitud,
+                          onDelete: () => _eliminarFoto(index),
                         );
                       },
                     ),

--- a/lib/features/flujo_visita/presentacion/widgets/foto_registro_item.dart
+++ b/lib/features/flujo_visita/presentacion/widgets/foto_registro_item.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+/// Elemento que muestra un registro fotográfico con opciones para eliminarlo.
+class FotoRegistroItem extends StatelessWidget {
+  const FotoRegistroItem({
+    super.key,
+    required this.path,
+    required this.titulo,
+    required this.descripcion,
+    required this.fecha,
+    required this.latitud,
+    required this.longitud,
+    this.onDelete,
+  });
+
+  /// Ruta del archivo de imagen.
+  final String path;
+
+  /// Título asociado a la fotografía.
+  final String titulo;
+
+  /// Descripción de la fotografía.
+  final String descripcion;
+
+  /// Fecha de captura de la fotografía.
+  final DateTime fecha;
+
+  /// Coordenada de latitud donde se tomó la fotografía.
+  final double latitud;
+
+  /// Coordenada de longitud donde se tomó la fotografía.
+  final double longitud;
+
+  /// Callback ejecutado al pulsar el botón de eliminar.
+  final VoidCallback? onDelete;
+
+  String _formatFecha(DateTime date) {
+    final dd = date.day.toString().padLeft(2, '0');
+    final mm = date.month.toString().padLeft(2, '0');
+    final yyyy = date.year.toString();
+    final hh = date.hour.toString().padLeft(2, '0');
+    final mi = date.minute.toString().padLeft(2, '0');
+    return '$dd/$mm/$yyyy $hh:$mi';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tituloMostrar = titulo.isEmpty ? 'Sin título' : titulo;
+    final descripcionMostrar =
+        descripcion.isEmpty ? 'Sin descripción' : descripcion;
+    final fechaMostrar = _formatFecha(fecha);
+    final coordenadasMostrar =
+        '(${latitud.toStringAsFixed(4)}, ${longitud.toStringAsFixed(4)})';
+
+    return ListTile(
+      leading: Image.file(
+        File(path),
+        width: 56,
+        height: 56,
+        fit: BoxFit.cover,
+      ),
+      title: Text(tituloMostrar),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(descripcionMostrar),
+          Text(fechaMostrar),
+          Text(coordenadasMostrar),
+        ],
+      ),
+      trailing: IconButton(
+        icon: const Icon(Icons.delete),
+        onPressed: onDelete,
+      ),
+      contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- create FotoRegistroItem widget to display photo details with delete button
- integrate FotoRegistroItem into photo verification page and implement deletion logic

## Testing
- `dart format lib/features/flujo_visita/presentacion/widgets/foto_registro_item.dart lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68993b34253883318c095efc6efbefd7