### PR TITLE
Format photo metadata

### DIFF
--- a/lib/features/flujo_visita/presentacion/widgets/foto_registro_item.dart
+++ b/lib/features/flujo_visita/presentacion/widgets/foto_registro_item.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 /// Elemento que muestra un registro fotográfico con opciones para eliminarlo.
 class FotoRegistroItem extends StatelessWidget {
@@ -37,12 +38,17 @@ class FotoRegistroItem extends StatelessWidget {
   final VoidCallback? onDelete;
 
   String _formatFecha(DateTime date) {
-    final dd = date.day.toString().padLeft(2, '0');
-    final mm = date.month.toString().padLeft(2, '0');
-    final yyyy = date.year.toString();
-    final hh = date.hour.toString().padLeft(2, '0');
-    final mi = date.minute.toString().padLeft(2, '0');
-    return '$dd/$mm/$yyyy $hh:$mi';
+    return DateFormat('dd/MM/yy HH:mm').format(date);
+  }
+
+  String _formatCoordenada(double valor, {required bool esLatitud}) {
+    final direccion = valor >= 0
+        ? (esLatitud ? 'N' : 'E')
+        : (esLatitud ? 'S' : 'O');
+    final valorAbs = valor.abs();
+    final grados = valorAbs.truncate();
+    final minutos = (valorAbs - grados) * 60;
+    return '$grados° ${minutos.toStringAsFixed(5)}\' $direccion';
   }
 
   @override
@@ -52,7 +58,8 @@ class FotoRegistroItem extends StatelessWidget {
         descripcion.isEmpty ? 'Sin descripción' : descripcion;
     final fechaMostrar = _formatFecha(fecha);
     final coordenadasMostrar =
-        '(${latitud.toStringAsFixed(4)}, ${longitud.toStringAsFixed(4)})';
+        '${_formatCoordenada(latitud, esLatitud: true)}, ${_formatCoordenada(longitud, esLatitud: false)}';
+    final infoMostrar = '$fechaMostrar - $coordenadasMostrar';
 
     return ListTile(
       leading: Image.file(
@@ -66,8 +73,7 @@ class FotoRegistroItem extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(descripcionMostrar),
-          Text(fechaMostrar),
-          Text(coordenadasMostrar),
+          Text(infoMostrar),
         ],
       ),
       trailing: IconButton(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   image_picker: ^1.0.4
   geolocator: ^10.1.0
   path_provider: ^2.1.2
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- format photo capture date with `intl`
- show coordinates in degrees/minutes with direction
- add intl dependency

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart format lib/features/flujo_visita/presentacion/widgets/foto_registro_item.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68993e586e04833190e202261754c9f2