### PR TITLE
Persistencia local de fotos de verificación

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   geolocator: ^10.1.0
   path_provider: ^2.1.2
   intl: ^0.19.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Guarda la lista de fotos de verificación en `SharedPreferences` usando JSON y la recarga al iniciar la página.
- Se añadió la dependencia `shared_preferences`.

## Testing
- `dart format lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart pubspec.yaml` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689940137cf88331b9efccc08b59b05a