### PR TITLE
feat: sync prospect condition catalog

### DIFF
--- a/lib/core/servicios/servicio_bd_local.dart
+++ b/lib/core/servicios/servicio_bd_local.dart
@@ -21,6 +21,8 @@ class ServicioBdLocal {
   static const String nombreTablaInicioProcesoFormalizacion =
       'inicio_proceso_formalizacion';
   static const String nombreTablaTipoActividad = 'tipo_actividad';
+  static const String nombreTablaCondicionProspecto =
+      'condicion_prospecto';
 
   static const _nombreBd = 'vinculacion.db';
   static const _versionBd = 1;
@@ -58,6 +60,12 @@ class ServicioBdLocal {
         await db.execute('''
           CREATE TABLE $nombreTablaTipoActividad(
             id INTEGER PRIMARY KEY,
+            descripcion TEXT
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE $nombreTablaCondicionProspecto(
+            id TEXT PRIMARY KEY,
             descripcion TEXT
           );
         ''');

--- a/lib/features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart
+++ b/lib/features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart
@@ -4,6 +4,7 @@ import 'package:veta_dorada_vinculacion_mobile/core/servicios/servicio_bd_local.
 
 import '../../dominio/entidades/inicio_proceso_formalizacion.dart';
 import '../../dominio/entidades/tipo_proveedor.dart';
+import '../../dominio/entidades/condicion_prospecto.dart';
 
 /// Fuente de datos local para almacenar y recuperar listas generales.
 class GeneralLocalDataSource {
@@ -15,6 +16,8 @@ class GeneralLocalDataSource {
       ServicioBdLocal.nombreTablaTipoProveedor;
   static const String _tablaIniciosFormalizacion =
       ServicioBdLocal.nombreTablaInicioProcesoFormalizacion;
+  static const String _tablaCondicionesProspecto =
+      ServicioBdLocal.nombreTablaCondicionProspecto;
 
   /// Reemplaza los tipos de proveedor almacenados.
   Future<void> reemplazarTiposProveedor(List<TipoProveedor> tipos) async {
@@ -73,6 +76,39 @@ class GeneralLocalDataSource {
     } on DatabaseException catch (e) {
       throw GeneralLocalException(
           'Error al obtener inicios formalización: $e');
+    }
+  }
+
+  /// Reemplaza las condiciones del prospecto almacenadas.
+  Future<void> reemplazarCondicionesProspecto(
+      List<CondicionProspecto> condiciones) async {
+    try {
+      await _bdLocal.delete(_tablaCondicionesProspecto);
+      for (final condicion in condiciones) {
+        await _bdLocal.insert(_tablaCondicionesProspecto, {
+          'id': condicion.id,
+          'descripcion': condicion.descripcion,
+        });
+      }
+    } on DatabaseException catch (e) {
+      throw GeneralLocalException(
+          'Error al guardar condiciones prospecto: $e');
+    }
+  }
+
+  /// Obtiene las condiciones del prospecto almacenadas.
+  Future<List<CondicionProspecto>> obtenerCondicionesProspecto() async {
+    try {
+      final rows = await _bdLocal.query(_tablaCondicionesProspecto);
+      return rows
+          .map((row) => CondicionProspecto(
+                id: row['id'] as String,
+                descripcion: row['descripcion'] as String,
+              ))
+          .toList();
+    } on DatabaseException catch (e) {
+      throw GeneralLocalException(
+          'Error al obtener condiciones prospecto: $e');
     }
   }
 }

--- a/lib/features/flujo_visita/datos/fuentes_datos/general_remote_data_source.dart
+++ b/lib/features/flujo_visita/datos/fuentes_datos/general_remote_data_source.dart
@@ -6,6 +6,7 @@ import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
 
 import '../../dominio/entidades/inicio_proceso_formalizacion.dart';
 import '../../dominio/entidades/tipo_proveedor.dart';
+import '../../dominio/entidades/condicion_prospecto.dart';
 
 /// Fuente de datos remota para obtener listas generales necesarias
 /// durante el flujo de visita.
@@ -78,6 +79,42 @@ class GeneralRemoteDataSource {
         codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
         mensajeError:
             'Error al obtener inicios de formalización: ${response.statusCode}',
+      );
+    }
+  }
+
+  /// Obtiene las condiciones del prospecto para verificación.
+  Future<RespuestaBase<List<CondicionProspecto>>>
+      obtenerCondicionesProspectoVerificacion() async {
+    final uri = Uri.parse(
+        '${EnvironmentConfig.apiBaseUrl}/api/general/condicionProspectoVerificacion');
+    final response = await _client.get(uri);
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> data =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      final codigo =
+          data['CodigoRespuesta'] as int? ?? RespuestaBase.RESPUESTA_ERROR;
+      if (codigo == RespuestaBase.RESPUESTA_CORRECTA &&
+          data['Respuesta'] is List) {
+        final condiciones = (data['Respuesta'] as List<dynamic>)
+            .map((e) =>
+                CondicionProspecto.fromJson(e as Map<String, dynamic>))
+            .toList();
+        return RespuestaBase(
+            codigoRespuesta: codigo, respuesta: condiciones);
+      } else {
+        return RespuestaBase(
+          codigoRespuesta: codigo,
+          mensajeError: data['MensajeError']?.toString() ??
+              'Error al obtener condiciones del prospecto',
+        );
+      }
+    } else {
+      return RespuestaBase(
+        codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
+        mensajeError:
+            'Error al obtener condiciones del prospecto: ${response.statusCode}',
       );
     }
   }

--- a/lib/features/flujo_visita/datos/repositorios/general_repository.dart
+++ b/lib/features/flujo_visita/datos/repositorios/general_repository.dart
@@ -2,6 +2,7 @@ import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
 
 import '../../dominio/entidades/inicio_proceso_formalizacion.dart';
 import '../../dominio/entidades/tipo_proveedor.dart';
+import '../../dominio/entidades/condicion_prospecto.dart';
 import '../fuentes_datos/general_local_data_source.dart';
 import '../fuentes_datos/general_remote_data_source.dart';
 
@@ -47,6 +48,22 @@ class GeneralRepository {
     }
   }
 
+  /// Obtiene las condiciones del prospecto desde la API y las almacena localmente.
+  Future<({List<CondicionProspecto> condiciones, String? advertencia})>
+      obtenerCondicionesProspecto() async {
+    final respuesta =
+        await _remoteDataSource.obtenerCondicionesProspectoVerificacion();
+    if (respuesta.codigoRespuesta == RespuestaBase.RESPUESTA_CORRECTA &&
+        respuesta.respuesta != null) {
+      await _localDataSource
+          .reemplazarCondicionesProspecto(respuesta.respuesta!);
+      return (condiciones: respuesta.respuesta!, advertencia: null);
+    } else {
+      final locales = await _localDataSource.obtenerCondicionesProspecto();
+      return (condiciones: locales, advertencia: respuesta.mensajeError);
+    }
+  }
+
   /// Sincroniza los catálogos generales al inicio de la aplicación.
   ///
   /// Borra los datos existentes y descarga los registros más recientes desde
@@ -71,6 +88,17 @@ class GeneralRepository {
           .reemplazarIniciosFormalizacion(iniciosRespuesta.respuesta!);
     } else {
       await _localDataSource.reemplazarIniciosFormalizacion(const []);
+    }
+
+    final condicionesRespuesta =
+        await _remoteDataSource.obtenerCondicionesProspectoVerificacion();
+    if (condicionesRespuesta.codigoRespuesta ==
+            RespuestaBase.RESPUESTA_CORRECTA &&
+        condicionesRespuesta.respuesta != null) {
+      await _localDataSource
+          .reemplazarCondicionesProspecto(condicionesRespuesta.respuesta!);
+    } else {
+      await _localDataSource.reemplazarCondicionesProspecto(const []);
     }
   }
 }

--- a/lib/features/flujo_visita/dominio/entidades/condicion_prospecto.dart
+++ b/lib/features/flujo_visita/dominio/entidades/condicion_prospecto.dart
@@ -1,0 +1,24 @@
+/// Representa una condición del prospecto verificada durante la visita.
+class CondicionProspecto {
+  /// Identificador único de la condición.
+  final String id;
+
+  /// Descripción de la condición.
+  final String descripcion;
+
+  /// Crea una instancia de [CondicionProspecto].
+  const CondicionProspecto({required this.id, required this.descripcion});
+
+  /// Crea un [CondicionProspecto] a partir de un mapa JSON.
+  factory CondicionProspecto.fromJson(Map<String, dynamic> json) =>
+      CondicionProspecto(
+        id: json['id'] as String,
+        descripcion: json['descripcion'] as String,
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'descripcion': descripcion,
+      };
+}


### PR DESCRIPTION
## Summary
- define `CondicionProspecto` domain entity with JSON helpers
- store prospect condition catalog locally and fetch from API
- expose repository and sync logic for prospect conditions

## Testing
- `flutter format lib/core/servicios/servicio_bd_local.dart lib/features/flujo_visita/dominio/entidades/condicion_prospecto.dart lib/features/flujo_visita/datos/fuentes_datos/general_local_data_source.dart lib/features/flujo_visita/datos/fuentes_datos/general_remote_data_source.dart lib/features/flujo_visita/datos/repositorios/general_repository.dart lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689953408898833191b5ae9e92187baf