### PR TITLE
feat: add digital signature flow

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
@@ -59,7 +59,7 @@ class _EvaluacionLaborPaginaState extends State<EvaluacionLaborPagina> {
     if (!_formKey.currentState!.validate()) {
       return;
     }
-    context.push('/flujo-visita/datos-proveedor', extra: widget.actividad);
+    context.push('/flujo-visita/firma', extra: widget.actividad);
   }
 
   @override

--- a/lib/features/flujo_visita/presentacion/paginas/firma_digital_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/firma_digital_pagina.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Pantalla temporal para la funcionalidad de firma digital.
+class FirmaDigitalPagina extends StatelessWidget {
+  const FirmaDigitalPagina({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Pantalla de firma digital (pendiente)'),
+      ),
+    );
+  }
+}
+

--- a/lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/auth/auth_provider.dart';
+import '../../../actividad/dominio/entidades/actividad.dart';
+import '../../../perfil/datos/modelos/usuario.dart';
+
+/// Página para visualizar la información del usuario antes de firmar.
+class FirmaPagina extends StatelessWidget {
+  const FirmaPagina({
+    super.key,
+    required this.actividad,
+    required this.usuario,
+  });
+
+  /// Actividad asociada a la firma.
+  final Actividad actividad; // ignore: unused_field
+
+  /// Usuario que realizará la firma.
+  final Usuario usuario;
+
+  @override
+  Widget build(BuildContext context) {
+    // Se obtiene el usuario autenticado por si cambia durante la navegación.
+    final currentUser = AuthProvider.of(context).usuario ?? usuario;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Firma')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('DNI: ${currentUser.id}'),
+            const SizedBox(height: 8),
+            Text('Nombre y apellidos: ${currentUser.nombre}'),
+            const SizedBox(height: 8),
+            Text('Cargo: ${currentUser.correo}'),
+            const SizedBox(height: 8),
+            const Text('Jefatura: -'),
+          ],
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: () =>
+                context.push('/flujo-visita/firma-digital'),
+            child: const Text('Firmar'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -20,6 +20,8 @@ import '../features/flujo_visita/presentacion/paginas/actividad_minera_verificad
 import '../features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart';
+import '../features/flujo_visita/presentacion/paginas/firma_pagina.dart';
+import '../features/flujo_visita/presentacion/paginas/firma_digital_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart';
 import '../features/visitas/presentacion/paginas/visitas_tabs_page.dart';
 
@@ -102,6 +104,21 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             repository: repo,
           );
         },
+      ),
+      GoRoute(
+        path: '/flujo-visita/firma',
+        builder: (context, state) {
+          final auth = AuthProvider.of(context);
+          final actividad = state.extra! as Actividad;
+          return FirmaPagina(
+            actividad: actividad,
+            usuario: auth.usuario!,
+          );
+        },
+      ),
+      GoRoute(
+        path: '/flujo-visita/firma-digital',
+        builder: (context, state) => const FirmaDigitalPagina(),
       ),
       GoRoute(
         path: '/flujo-visita/datos-proveedor',


### PR DESCRIPTION
## Summary
- show authenticated user info before signing
- add placeholder digital signature page
- wire new signature routes and adjust flow

## Testing
- `dart format lib/router/app_router.dart lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart lib/features/flujo_visita/presentacion/paginas/firma_digital_pagina.dart lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68995bc5b79483319d1b2678a271954e