### PR TITLE
Propaga flag de medición hacia diálogo de firma

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
@@ -16,10 +16,14 @@ class ActividadMineraVerificadaPagina extends StatefulWidget {
   const ActividadMineraVerificadaPagina({
     super.key,
     required this.repository,
+    required this.flagMedicionCapacidad,
   });
 
   /// Repositorio usado para obtener los tipos de actividad.
   final ActividadRepositoryImpl repository;
+
+  /// Indica si la visita requiere medición de capacidad.
+  final bool flagMedicionCapacidad;
 
   @override
   State<ActividadMineraVerificadaPagina> createState() =>
@@ -121,7 +125,10 @@ class _ActividadMineraVerificadaPaginaState
       descripcion: null,
     );
     context.push('/flujo-visita/descripcion-actividad-verificada',
-        extra: actividad);
+        extra: {
+          'actividad': actividad,
+          'flagMedicionCapacidad': widget.flagMedicionCapacidad,
+        });
   }
 
   @override

--- a/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
@@ -11,9 +11,11 @@ class DescripcionActividadMineraVerificadaPagina extends StatefulWidget {
   const DescripcionActividadMineraVerificadaPagina({
     super.key,
     required this.actividad,
+    required this.flagMedicionCapacidad,
   });
 
   final Actividad actividad;
+  final bool flagMedicionCapacidad;
 
   @override
   State<DescripcionActividadMineraVerificadaPagina> createState() =>
@@ -45,7 +47,10 @@ class _DescripcionActividadMineraVerificadaPaginaState
   void _siguiente() {
     if (_formKey.currentState!.validate()) {
       context.push('/flujo-visita/registro-fotografico',
-          extra: widget.actividad);
+          extra: {
+            'actividad': widget.actividad,
+            'flagMedicionCapacidad': widget.flagMedicionCapacidad,
+          });
     }
   }
 

--- a/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
@@ -14,6 +14,7 @@ class EvaluacionLaborPagina extends StatefulWidget {
     super.key,
     required this.actividad,
     required this.repository,
+    required this.flagMedicionCapacidad,
   });
 
   /// Actividad relacionada a la evaluación.
@@ -21,6 +22,9 @@ class EvaluacionLaborPagina extends StatefulWidget {
 
   /// Repositorio para obtener las condiciones del prospecto.
   final GeneralRepository repository;
+
+  /// Indica si la visita requiere medición de capacidad.
+  final bool flagMedicionCapacidad;
 
   @override
   State<EvaluacionLaborPagina> createState() => _EvaluacionLaborPaginaState();
@@ -59,7 +63,11 @@ class _EvaluacionLaborPaginaState extends State<EvaluacionLaborPagina> {
     if (!_formKey.currentState!.validate()) {
       return;
     }
-    context.push('/flujo-visita/firma', extra: widget.actividad);
+    context.push('/flujo-visita/firma',
+        extra: {
+          'actividad': widget.actividad,
+          'flagMedicionCapacidad': widget.flagMedicionCapacidad,
+        });
   }
 
   @override

--- a/lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart
@@ -11,6 +11,7 @@ class FirmaPagina extends StatelessWidget {
     super.key,
     required this.actividad,
     required this.usuario,
+    required this.flagMedicionCapacidad,
   });
 
   /// Actividad asociada a la firma.
@@ -18,6 +19,9 @@ class FirmaPagina extends StatelessWidget {
 
   /// Usuario que realizará la firma.
   final Usuario usuario;
+
+  /// Indica si la visita requiere medición de capacidad.
+  final bool flagMedicionCapacidad;
 
   @override
   Widget build(BuildContext context) {
@@ -46,8 +50,43 @@ class FirmaPagina extends StatelessWidget {
         child: SizedBox(
           width: double.infinity,
           child: ElevatedButton(
-            onPressed: () =>
-                context.push('/flujo-visita/firma-digital'),
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (context) {
+                  return AlertDialog(
+                    title: const Text('Informe verificación generado'),
+                    content: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('Fecha: ${DateTime.now()}'),
+                        Text('Coordenadas: '
+                            '${actividad.utmEste}, ${actividad.utmNorte}'),
+                      ],
+                    ),
+                    actions: [
+                      if (flagMedicionCapacidad)
+                        TextButton(
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                            context.push(
+                                '/flujo-visita/estimacion-produccion');
+                          },
+                          child: const Text('Ir a estimación producción'),
+                        ),
+                      TextButton(
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                          context.push('/flujo-visita/firma-digital');
+                        },
+                        child: const Text('Firmar digital'),
+                      ),
+                    ],
+                  );
+                },
+              );
+            },
             child: const Text('Firmar'),
           ),
         ),

--- a/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
@@ -20,9 +20,11 @@ class RegistroFotograficoVerificacionPagina extends StatefulWidget {
   const RegistroFotograficoVerificacionPagina({
     super.key,
     required this.actividad,
+    required this.flagMedicionCapacidad,
   });
 
   final Actividad actividad;
+  final bool flagMedicionCapacidad;
 
   @override
   State<RegistroFotograficoVerificacionPagina> createState() =>
@@ -121,7 +123,11 @@ class _RegistroFotograficoVerificacionPaginaState
   }
 
   void _siguiente() {
-    context.push('/flujo-visita/evaluacion-labor', extra: widget.actividad);
+    context.push('/flujo-visita/evaluacion-labor',
+        extra: {
+          'actividad': widget.actividad,
+          'flagMedicionCapacidad': widget.flagMedicionCapacidad,
+        });
   }
 
   Future<void> _guardarFotos() async {

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -60,15 +60,22 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             TipoActividadRemoteDataSource(ClienteHttp(token: auth.token!)),
             TipoActividadLocalDataSource(ServicioBdLocal()),
           );
-          return ActividadMineraVerificadaPagina(repository: repo);
+          final flag = state.extra as bool? ?? false;
+          return ActividadMineraVerificadaPagina(
+            repository: repo,
+            flagMedicionCapacidad: flag,
+          );
         },
       ),
       GoRoute(
         path: '/flujo-visita/descripcion-actividad-verificada',
         builder: (context, state) {
-          final actividad = state.extra! as Actividad;
+          final extras = state.extra! as Map<String, dynamic>;
+          final actividad = extras['actividad'] as Actividad;
+          final flag = extras['flagMedicionCapacidad'] as bool;
           return DescripcionActividadMineraVerificadaPagina(
             actividad: actividad,
+            flagMedicionCapacidad: flag,
           );
         },
       ),
@@ -86,8 +93,13 @@ GoRouter createRouter(AuthNotifier authNotifier) {
       GoRoute(
         path: '/flujo-visita/registro-fotografico',
         builder: (context, state) {
-          final actividad = state.extra! as Actividad;
-          return RegistroFotograficoVerificacionPagina(actividad: actividad);
+          final extras = state.extra! as Map<String, dynamic>;
+          final actividad = extras['actividad'] as Actividad;
+          final flag = extras['flagMedicionCapacidad'] as bool;
+          return RegistroFotograficoVerificacionPagina(
+            actividad: actividad,
+            flagMedicionCapacidad: flag,
+          );
         },
       ),
       GoRoute(
@@ -98,10 +110,13 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             GeneralRemoteDataSource(ClienteHttp(token: auth.token!)),
             GeneralLocalDataSource(ServicioBdLocal()),
           );
-          final actividad = state.extra! as Actividad;
+          final extras = state.extra! as Map<String, dynamic>;
+          final actividad = extras['actividad'] as Actividad;
+          final flag = extras['flagMedicionCapacidad'] as bool;
           return EvaluacionLaborPagina(
             actividad: actividad,
             repository: repo,
+            flagMedicionCapacidad: flag,
           );
         },
       ),
@@ -109,10 +124,13 @@ GoRouter createRouter(AuthNotifier authNotifier) {
         path: '/flujo-visita/firma',
         builder: (context, state) {
           final auth = AuthProvider.of(context);
-          final actividad = state.extra! as Actividad;
+          final extras = state.extra! as Map<String, dynamic>;
+          final actividad = extras['actividad'] as Actividad;
+          final flag = extras['flagMedicionCapacidad'] as bool;
           return FirmaPagina(
             actividad: actividad,
             usuario: auth.usuario!,
+            flagMedicionCapacidad: flag,
           );
         },
       ),

--- a/test/features/actividad/actividad_minera_verificada_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_verificada_pagina_test.dart
@@ -37,7 +37,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(MaterialApp(
-      home: ActividadMineraVerificadaPagina(repository: repo),
+      home: ActividadMineraVerificadaPagina(
+        repository: repo,
+        flagMedicionCapacidad: false,
+      ),
     ));
     await tester.pumpAndSettle();
 
@@ -55,7 +58,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(MaterialApp(
-      home: ActividadMineraVerificadaPagina(repository: repo),
+      home: ActividadMineraVerificadaPagina(
+        repository: repo,
+        flagMedicionCapacidad: false,
+      ),
     ));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- Propaga el flag `flagMedicionCapacidad` a través del flujo de visita y lo pasa a la página de firma
- Muestra un diálogo tras pulsar **Firmar** con opción condicional a estimación de producción
- Ajusta pruebas y rutas para soportar el nuevo parámetro

## Testing
- `flutter test` *(falla: command not found)*
- `dart test` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689964e1a8f4833189e6726f0acedee7