### PR TITLE
feat: add estimation production page with capacity flag

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/estimacion_produccion_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/estimacion_produccion_pagina.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+/// Página para estimar la producción de la operación.
+///
+/// Recibe un [flagMedicionCapacidad] que indica si la medición de
+/// capacidad está habilitada y muestra un indicador visual en consecuencia.
+class EstimacionProduccionPagina extends StatefulWidget {
+  const EstimacionProduccionPagina({
+    super.key,
+    required this.flagMedicionCapacidad,
+  });
+
+  /// Indica si se debe mostrar el indicador de capacidad operativa.
+  final bool flagMedicionCapacidad;
+
+  @override
+  State<EstimacionProduccionPagina> createState() =>
+      _EstimacionProduccionPaginaState();
+}
+
+class _EstimacionProduccionPaginaState
+    extends State<EstimacionProduccionPagina> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _capacidadController = TextEditingController();
+  final TextEditingController _diasController = TextEditingController();
+
+  double? _estimacion;
+
+  @override
+  void dispose() {
+    _capacidadController.dispose();
+    _diasController.dispose();
+    super.dispose();
+  }
+
+  void _calcular() {
+    if (!_formKey.currentState!.validate()) return;
+    final capacidad = double.tryParse(_capacidadController.text) ?? 0;
+    final dias = double.tryParse(_diasController.text) ?? 0;
+    setState(() {
+      _estimacion = capacidad * dias;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Estimación de Producción')),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            TextFormField(
+              controller: _capacidadController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(
+                labelText: 'Capacidad diaria (t)',
+              ),
+              validator: (value) =>
+                  value == null || value.isEmpty ? 'Ingrese la capacidad' : null,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _diasController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(
+                labelText: 'Días de operación',
+              ),
+              validator: (value) =>
+                  value == null || value.isEmpty ? 'Ingrese los días' : null,
+            ),
+            const SizedBox(height: 16),
+            Visibility(
+              visible: widget.flagMedicionCapacidad,
+              child: const Text('Capacidad operativa habilitada'),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _calcular,
+              child: const Text('Estimar'),
+            ),
+            if (_estimacion != null) ...[
+              const SizedBox(height: 16),
+              Text('Producción estimada: '
+                  '${_estimacion!.toStringAsFixed(2)}'),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
@@ -63,11 +63,8 @@ class _EvaluacionLaborPaginaState extends State<EvaluacionLaborPagina> {
     if (!_formKey.currentState!.validate()) {
       return;
     }
-    context.push('/flujo-visita/firma',
-        extra: {
-          'actividad': widget.actividad,
-          'flagMedicionCapacidad': widget.flagMedicionCapacidad,
-        });
+    context.push('/flujo-visita/estimacion-produccion',
+        extra: widget.flagMedicionCapacidad);
   }
 
   @override

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -23,6 +23,7 @@ import '../features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.da
 import '../features/flujo_visita/presentacion/paginas/firma_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/firma_digital_pagina.dart';
 import '../features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart';
+import '../features/flujo_visita/presentacion/paginas/estimacion_produccion_pagina.dart';
 import '../features/visitas/presentacion/paginas/visitas_tabs_page.dart';
 
 /// Crea la configuración del enrutador principal de la aplicación.
@@ -116,6 +117,15 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           return EvaluacionLaborPagina(
             actividad: actividad,
             repository: repo,
+            flagMedicionCapacidad: flag,
+          );
+        },
+      ),
+      GoRoute(
+        path: '/flujo-visita/estimacion-produccion',
+        builder: (context, state) {
+          final flag = state.extra as bool? ?? false;
+          return EstimacionProduccionPagina(
             flagMedicionCapacidad: flag,
           );
         },

--- a/test/features/flujo_visita/estimacion_produccion_pagina_test.dart
+++ b/test/features/flujo_visita/estimacion_produccion_pagina_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/presentacion/paginas/estimacion_produccion_pagina.dart';
+
+void main() {
+  testWidgets('muestra indicador cuando flag es true', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: EstimacionProduccionPagina(flagMedicionCapacidad: true),
+    ));
+
+    expect(find.text('Capacidad operativa habilitada'), findsOneWidget);
+  });
+
+  testWidgets('oculta indicador cuando flag es false', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: EstimacionProduccionPagina(flagMedicionCapacidad: false),
+    ));
+
+    expect(find.text('Capacidad operativa habilitada'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add production estimation page displaying capacity flag
- register route and propagate flag from evaluation page
- cover page visibility with widget tests

## Testing
- `flutter test test/features/flujo_visita/estimacion_produccion_pagina_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a264c38d083318da05875e211104c