### PR TITLE
feat: completar flujo de visita

### DIFF
--- a/lib/features/flujo_visita/datos/fuentes_datos/verificacion_remote_data_source.dart
+++ b/lib/features/flujo_visita/datos/fuentes_datos/verificacion_remote_data_source.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import '../../../../core/config/environment_config.dart';
+import '../../../../core/red/cliente_http.dart';
+import '../../dominio/entidades/completar_visita_comando.dart';
+
+/// Fuente de datos remota para actualizar la verificación de una visita.
+class VerificacionRemoteDataSource {
+  VerificacionRemoteDataSource(this._client);
+
+  final ClienteHttp _client;
+
+  /// Envía al servidor la información recopilada durante la visita.
+  Future<void> actualizarVerificacion(CompletarVisitaComando comando) async {
+    final uri = Uri.parse(
+        '${EnvironmentConfig.apiBaseUrl}/api/visitas/${comando.idVisita}/verificacion');
+    final response = await _client.put(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(comando.toJson()),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+          'Error al actualizar verificación: ${response.statusCode}');
+    }
+  }
+}
+

--- a/lib/features/flujo_visita/datos/repositorios/flow_repository_impl.dart
+++ b/lib/features/flujo_visita/datos/repositorios/flow_repository_impl.dart
@@ -1,9 +1,15 @@
 import '../../dominio/entidades/descripcion_actividad_verificada.dart';
 import '../../dominio/entidades/registro_fotografico.dart';
+import '../../dominio/entidades/completar_visita_comando.dart';
 import '../../dominio/repositorios/flow_repository.dart';
+import '../fuentes_datos/verificacion_remote_data_source.dart';
 
 /// Implementación en memoria de [FlowRepository].
 class FlowRepositoryImpl implements FlowRepository {
+  FlowRepositoryImpl(this._verificacionRemoteDataSource);
+
+  final VerificacionRemoteDataSource _verificacionRemoteDataSource;
+
   DescripcionActividadVerificada? _descripcion;
   final List<RegistroFotografico> _fotos = [];
 
@@ -27,6 +33,11 @@ class FlowRepositoryImpl implements FlowRepository {
   @override
   Future<List<RegistroFotografico>> obtenerFotosVerificacion() async {
     return List.unmodifiable(_fotos);
+  }
+
+  @override
+  Future<void> completarFlujo(CompletarVisitaComando comando) async {
+    await _verificacionRemoteDataSource.actualizarVerificacion(comando);
   }
 }
 

--- a/lib/features/flujo_visita/dominio/casos_uso/completar_flujo.dart
+++ b/lib/features/flujo_visita/dominio/casos_uso/completar_flujo.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import '../../datos/fuentes_datos/documento_remote_data_source.dart';
+import '../entidades/completar_visita_comando.dart';
+import '../entidades/foto.dart';
+import '../repositorios/flow_repository.dart';
+
+/// Caso de uso encargado de completar el flujo de visita.
+///
+/// Sube las fotografías al servidor, reemplaza sus rutas locales por las
+/// URL retornadas y finalmente envía el comando completo al repositorio.
+class CompletarFlujo {
+  CompletarFlujo(this._documentoRemote, this._repository);
+
+  final DocumentoRemoteDataSource _documentoRemote;
+  final FlowRepository _repository;
+
+  Future<void> call(CompletarVisitaComando comando) async {
+    final List<Foto> fotosActualizadas = [];
+    for (final foto in comando.fotos) {
+      final file = File(foto.imagen);
+      final url = await _documentoRemote.subirDocumento(file);
+      fotosActualizadas.add(
+        Foto(
+          imagen: url,
+          titulo: foto.titulo,
+          descripcion: foto.descripcion,
+          fecha: foto.fecha,
+          latitud: foto.latitud,
+          longitud: foto.longitud,
+        ),
+      );
+    }
+
+    final actualizado = CompletarVisitaComando(
+      idVisita: comando.idVisita,
+      proveedor: comando.proveedor,
+      actividad: comando.actividad,
+      descripcion: comando.descripcion,
+      evaluacion: comando.evaluacion,
+      estimacion: comando.estimacion,
+      fotos: fotosActualizadas,
+    );
+
+    await _repository.completarFlujo(actualizado);
+  }
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/actividad.dart
+++ b/lib/features/flujo_visita/dominio/entidades/actividad.dart
@@ -1,0 +1,56 @@
+/// Información de la actividad minera registrada durante la visita.
+class Actividad {
+  /// Identificador del tipo de actividad.
+  final int idTipoActividad;
+
+  /// Identificador del sub tipo de actividad.
+  final int idSubTipoActividad;
+
+  /// Sistema UTM utilizado.
+  final int? sistemaUtm;
+
+  /// Zona UTM.
+  final int? zonaUtm;
+
+  /// Coordenada Este.
+  final double utmEste;
+
+  /// Coordenada Norte.
+  final double utmNorte;
+
+  /// Derecho minero asociado si aplica.
+  final String? derechoMinero;
+
+  const Actividad({
+    required this.idTipoActividad,
+    required this.idSubTipoActividad,
+    this.sistemaUtm,
+    this.zonaUtm,
+    required this.utmEste,
+    required this.utmNorte,
+    this.derechoMinero,
+  });
+
+  /// Crea una [Actividad] a partir de un mapa JSON.
+  factory Actividad.fromJson(Map<String, dynamic> json) => Actividad(
+        idTipoActividad: json['idTipoActividad'] as int,
+        idSubTipoActividad: json['idSubTipoActividad'] as int,
+        sistemaUtm: json['sistemaUtm'] as int?,
+        zonaUtm: json['zonaUtm'] as int?,
+        utmEste: (json['utmEste'] as num).toDouble(),
+        utmNorte: (json['utmNorte'] as num).toDouble(),
+        derechoMinero: json['derechoMinero'] as String?,
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'idTipoActividad': idTipoActividad,
+        'idSubTipoActividad': idSubTipoActividad,
+        'sistemaUtm': sistemaUtm,
+        'zonaUtm': zonaUtm,
+        'utmEste': utmEste,
+        'utmNorte': utmNorte,
+        'derechoMinero': derechoMinero,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/completar_visita_comando.dart
+++ b/lib/features/flujo_visita/dominio/entidades/completar_visita_comando.dart
@@ -1,0 +1,70 @@
+import 'actividad.dart';
+import 'descripcion.dart';
+import 'estimacion.dart';
+import 'evaluacion.dart';
+import 'foto.dart';
+import 'proveedor_snapshot.dart';
+
+/// Comando para completar la verificación de una visita.
+class CompletarVisitaComando {
+  /// Identificador de la visita que se actualiza.
+  final int idVisita;
+
+  /// Información del proveedor al momento de la visita.
+  final ProveedorSnapshot proveedor;
+
+  /// Actividad minera registrada.
+  final Actividad actividad;
+
+  /// Descripción detallada de la actividad.
+  final Descripcion descripcion;
+
+  /// Evaluación realizada durante la visita.
+  final Evaluacion evaluacion;
+
+  /// Estimación de producción calculada.
+  final Estimacion estimacion;
+
+  /// Registro fotográfico asociado.
+  final List<Foto> fotos;
+
+  const CompletarVisitaComando({
+    required this.idVisita,
+    required this.proveedor,
+    required this.actividad,
+    required this.descripcion,
+    required this.evaluacion,
+    required this.estimacion,
+    required this.fotos,
+  });
+
+  /// Crea un [CompletarVisitaComando] a partir de un mapa JSON.
+  factory CompletarVisitaComando.fromJson(Map<String, dynamic> json) =>
+      CompletarVisitaComando(
+        idVisita: json['idVisita'] as int,
+        proveedor:
+            ProveedorSnapshot.fromJson(json['proveedor'] as Map<String, dynamic>),
+        actividad: Actividad.fromJson(json['actividad'] as Map<String, dynamic>),
+        descripcion:
+            Descripcion.fromJson(json['descripcion'] as Map<String, dynamic>),
+        evaluacion:
+            Evaluacion.fromJson(json['evaluacion'] as Map<String, dynamic>),
+        estimacion:
+            Estimacion.fromJson(json['estimacion'] as Map<String, dynamic>),
+        fotos: (json['fotos'] as List<dynamic>)
+            .map((e) => Foto.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  /// Convierte el comando en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'idVisita': idVisita,
+        'proveedor': proveedor.toJson(),
+        'actividad': actividad.toJson(),
+        'descripcion': descripcion.toJson(),
+        'evaluacion': evaluacion.toJson(),
+        'estimacion': estimacion.toJson(),
+        'fotos': fotos.map((e) => e.toJson()).toList(),
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/descripcion.dart
+++ b/lib/features/flujo_visita/dominio/entidades/descripcion.dart
@@ -1,0 +1,50 @@
+/// Describe la actividad minera observada durante la visita.
+class Descripcion {
+  /// Coordenadas y ubicación geográfica y política.
+  final String coordenadas;
+
+  /// Zona de la labor minera.
+  final String zona;
+
+  /// Actividad minera verificada.
+  final String actividad;
+
+  /// Equipos y maquinaria observados.
+  final String equipos;
+
+  /// Trabajadores presentes en la actividad.
+  final String trabajadores;
+
+  /// Condiciones laborales y de seguridad observadas.
+  final String condicionesLaborales;
+
+  const Descripcion({
+    required this.coordenadas,
+    required this.zona,
+    required this.actividad,
+    required this.equipos,
+    required this.trabajadores,
+    required this.condicionesLaborales,
+  });
+
+  /// Crea una [Descripcion] a partir de un mapa JSON.
+  factory Descripcion.fromJson(Map<String, dynamic> json) => Descripcion(
+        coordenadas: json['coordenadas'] as String,
+        zona: json['zona'] as String,
+        actividad: json['actividad'] as String,
+        equipos: json['equipos'] as String,
+        trabajadores: json['trabajadores'] as String,
+        condicionesLaborales: json['condicionesLaborales'] as String,
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'coordenadas': coordenadas,
+        'zona': zona,
+        'actividad': actividad,
+        'equipos': equipos,
+        'trabajadores': trabajadores,
+        'condicionesLaborales': condicionesLaborales,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/estimacion.dart
+++ b/lib/features/flujo_visita/dominio/entidades/estimacion.dart
@@ -1,0 +1,32 @@
+/// Estimación de producción calculada durante la visita.
+class Estimacion {
+  /// Capacidad diaria de producción.
+  final double capacidadDiaria;
+
+  /// Días de operación considerados.
+  final double diasOperacion;
+
+  /// Resultado de la estimación.
+  final double produccionEstimada;
+
+  const Estimacion({
+    required this.capacidadDiaria,
+    required this.diasOperacion,
+    required this.produccionEstimada,
+  });
+
+  /// Crea una [Estimacion] a partir de un mapa JSON.
+  factory Estimacion.fromJson(Map<String, dynamic> json) => Estimacion(
+        capacidadDiaria: (json['capacidadDiaria'] as num).toDouble(),
+        diasOperacion: (json['diasOperacion'] as num).toDouble(),
+        produccionEstimada: (json['produccionEstimada'] as num).toDouble(),
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'capacidadDiaria': capacidadDiaria,
+        'diasOperacion': diasOperacion,
+        'produccionEstimada': produccionEstimada,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/evaluacion.dart
+++ b/lib/features/flujo_visita/dominio/entidades/evaluacion.dart
@@ -1,0 +1,26 @@
+/// Evaluación de la labor realizada durante la visita.
+class Evaluacion {
+  /// Identificador de la condición del prospecto.
+  final int idCondicionProspecto;
+
+  /// Anotaciones adicionales de la evaluación.
+  final String? anotacion;
+
+  const Evaluacion({
+    required this.idCondicionProspecto,
+    this.anotacion,
+  });
+
+  /// Crea una [Evaluacion] a partir de un mapa JSON.
+  factory Evaluacion.fromJson(Map<String, dynamic> json) => Evaluacion(
+        idCondicionProspecto: json['idCondicionProspecto'] as int,
+        anotacion: json['anotacion'] as String?,
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'idCondicionProspecto': idCondicionProspecto,
+        'anotacion': anotacion,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/foto.dart
+++ b/lib/features/flujo_visita/dominio/entidades/foto.dart
@@ -1,0 +1,50 @@
+/// Fotografía registrada durante la visita.
+class Foto {
+  /// Ruta local o URL de la imagen.
+  final String imagen;
+
+  /// Título que describe el contenido.
+  final String titulo;
+
+  /// Descripción detallada de lo observado.
+  final String descripcion;
+
+  /// Fecha de captura de la foto.
+  final DateTime fecha;
+
+  /// Latitud donde se capturó la foto.
+  final double latitud;
+
+  /// Longitud donde se capturó la foto.
+  final double longitud;
+
+  const Foto({
+    required this.imagen,
+    required this.titulo,
+    required this.descripcion,
+    required this.fecha,
+    required this.latitud,
+    required this.longitud,
+  });
+
+  /// Crea una [Foto] a partir de un mapa JSON.
+  factory Foto.fromJson(Map<String, dynamic> json) => Foto(
+        imagen: json['imagen'] as String,
+        titulo: json['titulo'] as String,
+        descripcion: json['descripcion'] as String,
+        fecha: DateTime.parse(json['fecha'] as String),
+        latitud: (json['latitud'] as num).toDouble(),
+        longitud: (json['longitud'] as num).toDouble(),
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'imagen': imagen,
+        'titulo': titulo,
+        'descripcion': descripcion,
+        'fecha': fecha.toIso8601String(),
+        'latitud': latitud,
+        'longitud': longitud,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/proveedor_snapshot.dart
+++ b/lib/features/flujo_visita/dominio/entidades/proveedor_snapshot.dart
@@ -1,0 +1,52 @@
+/// Representa un resumen de la información del proveedor.
+class ProveedorSnapshot {
+  /// Tipo de persona del proveedor (NATURAL o JURIDICA).
+  final String tipoPersona;
+
+  /// Nombre del proveedor o representante.
+  final String nombre;
+
+  /// Número de RUC en caso de persona jurídica.
+  final String? ruc;
+
+  /// Razón social si aplica.
+  final String? razonSocial;
+
+  /// Nombre del representante legal si aplica.
+  final String? representanteLegal;
+
+  /// Indica si inició el proceso de formalización.
+  final bool inicioFormalizacion;
+
+  /// Crea una instancia de [ProveedorSnapshot].
+  const ProveedorSnapshot({
+    required this.tipoPersona,
+    required this.nombre,
+    this.ruc,
+    this.razonSocial,
+    this.representanteLegal,
+    required this.inicioFormalizacion,
+  });
+
+  /// Crea un [ProveedorSnapshot] a partir de un mapa JSON.
+  factory ProveedorSnapshot.fromJson(Map<String, dynamic> json) =>
+      ProveedorSnapshot(
+        tipoPersona: json['tipoPersona'] as String,
+        nombre: json['nombre'] as String,
+        ruc: json['ruc'] as String?,
+        razonSocial: json['razonSocial'] as String?,
+        representanteLegal: json['representanteLegal'] as String?,
+        inicioFormalizacion: json['inicioFormalizacion'] as bool? ?? false,
+      );
+
+  /// Convierte la entidad en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'tipoPersona': tipoPersona,
+        'nombre': nombre,
+        'ruc': ruc,
+        'razonSocial': razonSocial,
+        'representanteLegal': representanteLegal,
+        'inicioFormalizacion': inicioFormalizacion,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/repositorios/flow_repository.dart
+++ b/lib/features/flujo_visita/dominio/repositorios/flow_repository.dart
@@ -1,5 +1,6 @@
 import '../entidades/descripcion_actividad_verificada.dart';
 import '../entidades/registro_fotografico.dart';
+import '../entidades/completar_visita_comando.dart';
 
 /// Repositorio para manejar los datos del flujo de visita.
 abstract class FlowRepository {
@@ -16,5 +17,8 @@ abstract class FlowRepository {
 
   /// Obtiene la lista de registros fotográficos agregados.
   Future<List<RegistroFotografico>> obtenerFotosVerificacion();
+
+  /// Completa el flujo enviando la información recopilada al servidor.
+  Future<void> completarFlujo(CompletarVisitaComando comando);
 }
 


### PR DESCRIPTION
## Summary
- add domain models for CompletarVisitaComando and related entities
- add remote data source and repository method to update visit verification
- implement CompletarFlujo use case and wire it into the summary page

## Testing
- `dart format lib/features/flujo_visita/dominio/entidades lib/features/flujo_visita/datos lib/features/flujo_visita/presentacion/paginas/resumen_page.dart lib/features/flujo_visita/dominio/casos_uso/completar_flujo.dart` (fail: command not found)
- `flutter test` (fail: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689e678e4ed483318114e1fe9446efff