### PR TITLE
Use authenticated HTTP client for document uploads

### DIFF
--- a/lib/core/auth/auth_http_client.dart
+++ b/lib/core/auth/auth_http_client.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/widgets.dart';
+
+import '../red/cliente_http.dart';
+import 'auth_provider.dart';
+
+/// Devuelve un [ClienteHttp] configurado con el token del usuario autenticado.
+ClienteHttp authenticatedClient(BuildContext context) {
+  final auth = AuthProvider.of(context);
+  return ClienteHttp(token: auth.token ?? '');
+}

--- a/lib/features/flujo_visita/presentacion/paginas/resumen_page.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/resumen_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../../core/red/cliente_http.dart';
+import '../../../../core/auth/auth_http_client.dart';
 import '../../../datos/fuentes_datos/documento_remote_data_source.dart';
 import '../../../datos/repositorios/flow_repository_impl.dart';
 import '../../dominio/casos_uso/completar_flujo.dart';
@@ -23,16 +23,17 @@ class ResumenPage extends StatefulWidget {
 
 class _ResumenPageState extends State<ResumenPage> {
   late final CompletarFlujo _completarFlujo;
+  bool _initialized = false;
 
   bool _enviando = false;
 
   @override
-  void initState() {
-    super.initState();
-    // En un escenario real el token provendría del proceso de autenticación.
-    final client = ClienteHttp(token: '');
-    final documento = DocumentoRemoteDataSource(client);
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+    final documento = DocumentoRemoteDataSource(authenticatedClient(context));
     _completarFlujo = CompletarFlujo(documento, widget.repository);
+    _initialized = true;
   }
 
   Future<bool> _formulariosCompletos() async {


### PR DESCRIPTION
## Summary
- add helper to build ClienteHttp using auth token
- update ResumenPage to send documents with authenticated client

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e6f294774833193802fe2104d5af5