### PR TITLE
Refactor proveedor mineral page to load dropdowns from repository

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -171,8 +171,16 @@ GoRouter createRouter(AuthNotifier authNotifier) {
       GoRoute(
         path: '/flujo-visita/datos-proveedor',
         builder: (context, state) {
+          final auth = AuthProvider.of(context);
+          final repo = GeneralRepository(
+            GeneralRemoteDataSource(ClienteHttp(token: auth.token!)),
+            GeneralLocalDataSource(ServicioBdLocal()),
+          );
           final visita = state.extra! as Visita;
-          return DatosProveedorMineralPagina(visita: visita);
+          return DatosProveedorMineralPagina(
+            visita: visita,
+            repository: repo,
+          );
         },
       ),
       StatefulShellRoute.indexedStack(


### PR DESCRIPTION
## Summary
- inject GeneralRepository into DatosProveedorMineralPagina
- load tipos de proveedor and inicio formalización from repository and build dropdowns
- update router to provide repository when navigating to datos proveedor page

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa583c60a48331a58cdedf7ba2d6e8