### PR TITLE
Prefill supplier data in visit form

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart
@@ -43,6 +43,11 @@ class _DatosProveedorMineralPaginaState
   @override
   void initState() {
     super.initState();
+    final proveedor = widget.visita.proveedor;
+    _nombreController.text = proveedor.nombreCompleto ?? '';
+    _rucController.text = proveedor.ruc;
+    _razonSocialController.text = proveedor.razonSocial ?? '';
+    _representanteController.text = proveedor.representanteNombre ?? '';
     _cargarCatalogos();
   }
 


### PR DESCRIPTION
## Summary
- Load `widget.visita.proveedor` into name, RUC, reason social, and representative controllers before fetching catalogs

## Testing
- `dart analyze` *(command not found: dart)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b4cdd948331af666a39c02aa522