### PR TITLE
Add local verification storage

### DIFF
--- a/lib/core/servicios/servicio_bd_local.dart
+++ b/lib/core/servicios/servicio_bd_local.dart
@@ -23,9 +23,11 @@ class ServicioBdLocal {
   static const String nombreTablaTipoActividad = 'tipo_actividad';
   static const String nombreTablaCondicionProspecto =
       'condicion_prospecto';
+  static const String nombreTablaRealizarVerificacion =
+      'realizar_verificacion';
 
   static const _nombreBd = 'vinculacion.db';
-  static const _versionBd = 2;
+  static const _versionBd = 3;
 
   Database? _db;
 
@@ -69,6 +71,12 @@ class ServicioBdLocal {
             descripcion TEXT
           );
         ''');
+        await db.execute('''
+          CREATE TABLE $nombreTablaRealizarVerificacion(
+            idVisita TEXT PRIMARY KEY,
+            data TEXT
+          );
+        ''');
       },
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -94,6 +102,14 @@ class ServicioBdLocal {
             CREATE TABLE IF NOT EXISTS $nombreTablaCondicionProspecto(
               id TEXT PRIMARY KEY,
               descripcion TEXT
+            );
+          ''');
+        }
+        if (oldVersion < 3) {
+          await db.execute('''
+            CREATE TABLE IF NOT EXISTS $nombreTablaRealizarVerificacion(
+              idVisita TEXT PRIMARY KEY,
+              data TEXT
             );
           ''');
         }

--- a/lib/features/flujo_visita/datos/fuentes_datos/verificacion_local_data_source.dart
+++ b/lib/features/flujo_visita/datos/fuentes_datos/verificacion_local_data_source.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:sqflite/sqflite.dart';
+
+import '../../../../core/servicios/servicio_bd_local.dart';
+import '../../dominio/entidades/realizar_verificacion_dto.dart';
+
+/// Fuente de datos local para almacenar la información de verificación.
+class VerificacionLocalDataSource {
+  VerificacionLocalDataSource(this._bdLocal);
+
+  final ServicioBdLocal _bdLocal;
+
+  static const String _tabla =
+      ServicioBdLocal.nombreTablaRealizarVerificacion;
+
+  /// Inserta o actualiza una verificación.
+  Future<void> upsertVerificacion(RealizarVerificacionDto dto) async {
+    try {
+      await _bdLocal.insert(_tabla, {
+        'idVisita': dto.idVisita.toString(),
+        'data': jsonEncode(dto.toJson()),
+      });
+    } on DatabaseException catch (e) {
+      throw VerificacionLocalException(
+          'Error al guardar verificación: $e');
+    }
+  }
+
+  /// Obtiene la verificación almacenada para [idVisita].
+  Future<RealizarVerificacionDto?> obtenerVerificacion(int idVisita) async {
+    try {
+      final rows = await _bdLocal.query(
+        _tabla,
+        where: 'idVisita = ?',
+        whereArgs: [idVisita.toString()],
+      );
+      if (rows.isEmpty) return null;
+      final data =
+          jsonDecode(rows.first['data'] as String) as Map<String, dynamic>;
+      return RealizarVerificacionDto.fromJson(data);
+    } on DatabaseException catch (e) {
+      throw VerificacionLocalException(
+          'Error al obtener verificación: $e');
+    }
+  }
+}
+
+/// Excepción lanzada para errores de acceso a datos de verificación local.
+class VerificacionLocalException implements Exception {
+  VerificacionLocalException(this.message);
+  final String message;
+  @override
+  String toString() => 'VerificacionLocalException: $message';
+}
+

--- a/lib/features/flujo_visita/datos/repositorios/verificacion_repository_impl.dart
+++ b/lib/features/flujo_visita/datos/repositorios/verificacion_repository_impl.dart
@@ -1,0 +1,22 @@
+import '../../dominio/entidades/realizar_verificacion_dto.dart';
+import '../../dominio/repositorios/verificacion_repository.dart';
+import '../fuentes_datos/verificacion_local_data_source.dart';
+
+/// Implementación de [VerificacionRepository] que utiliza una fuente de datos
+/// local para persistir la información de la verificación.
+class VerificacionRepositoryImpl implements VerificacionRepository {
+  VerificacionRepositoryImpl(this._localDataSource);
+
+  final VerificacionLocalDataSource _localDataSource;
+
+  @override
+  Future<void> guardarVerificacion(RealizarVerificacionDto dto) async {
+    await _localDataSource.upsertVerificacion(dto);
+  }
+
+  @override
+  Future<RealizarVerificacionDto?> obtenerVerificacion(int idVisita) async {
+    return _localDataSource.obtenerVerificacion(idVisita);
+  }
+}
+

--- a/lib/features/flujo_visita/dominio/entidades/realizar_verificacion_dto.dart
+++ b/lib/features/flujo_visita/dominio/entidades/realizar_verificacion_dto.dart
@@ -1,0 +1,102 @@
+import 'actividad.dart';
+import 'descripcion.dart';
+import 'evaluacion.dart';
+import 'estimacion.dart';
+import 'foto.dart';
+import 'proveedor_snapshot.dart';
+
+/// DTO que agrupa la información necesaria para realizar una verificación.
+class RealizarVerificacionDto {
+  /// Identificador de la verificación.
+  final int idVerificacion;
+
+  /// Identificador de la visita asociada.
+  final int idVisita;
+
+  /// Identificador del usuario que realiza la verificación.
+  final int idUsuario;
+
+  /// Fecha y hora de inicio registrada en el dispositivo móvil.
+  final DateTime fechaInicioMovil;
+
+  /// Fecha y hora de fin registrada en el dispositivo móvil.
+  final DateTime fechaFinMovil;
+
+  /// Información del proveedor al momento de la verificación.
+  final ProveedorSnapshot proveedorSnapshot;
+
+  /// Lista de actividades observadas.
+  final List<Actividad> actividades;
+
+  /// Descripción detallada de la actividad verificada.
+  final Descripcion descripcion;
+
+  /// Evaluación realizada durante la visita.
+  final Evaluacion evaluacion;
+
+  /// Estimación de producción obtenida.
+  final Estimacion estimacion;
+
+  /// Registro fotográfico asociado a la verificación.
+  final List<Foto> fotos;
+
+  /// Clave de idempotencia para evitar duplicados en el servidor.
+  final String idempotencyKey;
+
+  const RealizarVerificacionDto({
+    required this.idVerificacion,
+    required this.idVisita,
+    required this.idUsuario,
+    required this.fechaInicioMovil,
+    required this.fechaFinMovil,
+    required this.proveedorSnapshot,
+    required this.actividades,
+    required this.descripcion,
+    required this.evaluacion,
+    required this.estimacion,
+    required this.fotos,
+    required this.idempotencyKey,
+  });
+
+  /// Crea una instancia a partir de un mapa JSON.
+  factory RealizarVerificacionDto.fromJson(Map<String, dynamic> json) =>
+      RealizarVerificacionDto(
+        idVerificacion: json['idVerificacion'] as int,
+        idVisita: json['idVisita'] as int,
+        idUsuario: json['idUsuario'] as int,
+        fechaInicioMovil: DateTime.parse(json['fechaInicioMovil'] as String),
+        fechaFinMovil: DateTime.parse(json['fechaFinMovil'] as String),
+        proveedorSnapshot: ProveedorSnapshot.fromJson(
+            json['proveedorSnapshot'] as Map<String, dynamic>),
+        actividades: (json['actividades'] as List<dynamic>)
+            .map((e) => Actividad.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        descripcion:
+            Descripcion.fromJson(json['descripcion'] as Map<String, dynamic>),
+        evaluacion:
+            Evaluacion.fromJson(json['evaluacion'] as Map<String, dynamic>),
+        estimacion:
+            Estimacion.fromJson(json['estimacion'] as Map<String, dynamic>),
+        fotos: (json['fotos'] as List<dynamic>)
+            .map((e) => Foto.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        idempotencyKey: json['idempotencyKey'] as String,
+      );
+
+  /// Convierte la instancia en un mapa JSON.
+  Map<String, dynamic> toJson() => {
+        'idVerificacion': idVerificacion,
+        'idVisita': idVisita,
+        'idUsuario': idUsuario,
+        'fechaInicioMovil': fechaInicioMovil.toIso8601String(),
+        'fechaFinMovil': fechaFinMovil.toIso8601String(),
+        'proveedorSnapshot': proveedorSnapshot.toJson(),
+        'actividades': actividades.map((e) => e.toJson()).toList(),
+        'descripcion': descripcion.toJson(),
+        'evaluacion': evaluacion.toJson(),
+        'estimacion': estimacion.toJson(),
+        'fotos': fotos.map((e) => e.toJson()).toList(),
+        'idempotencyKey': idempotencyKey,
+      };
+}
+

--- a/lib/features/flujo_visita/dominio/repositorios/verificacion_repository.dart
+++ b/lib/features/flujo_visita/dominio/repositorios/verificacion_repository.dart
@@ -1,0 +1,11 @@
+import '../entidades/realizar_verificacion_dto.dart';
+
+/// Repositorio para gestionar la información de verificación de visitas.
+abstract class VerificacionRepository {
+  /// Guarda localmente la información de la verificación.
+  Future<void> guardarVerificacion(RealizarVerificacionDto dto);
+
+  /// Obtiene la información de verificación almacenada para [idVisita].
+  Future<RealizarVerificacionDto?> obtenerVerificacion(int idVisita);
+}
+


### PR DESCRIPTION
## Summary
- add RealizarVerificacionDto with JSON serialization
- create local database table and datasource for verifications
- expose VerificacionRepository to handle saving and loading

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5d6c4d9883318eb320b8e7e931c1