### PR TITLE
Filtra visitas programadas por verificación en curso

### DIFF
--- a/lib/features/visitas/presentacion/bloc/visitas_bloc.dart
+++ b/lib/features/visitas/presentacion/bloc/visitas_bloc.dart
@@ -5,17 +5,20 @@ import '../../datos/fuentes_datos/visits_local_data_source.dart'
 import '../../dominio/entidades/estado_visita.dart';
 import '../../dominio/entidades/visita.dart';
 import '../../dominio/repositorios/visits_repository.dart';
+import '../../../flujo_visita/dominio/repositorios/verificacion_repository.dart';
 
 part 'visitas_event.dart';
 part 'visitas_state.dart';
 
 class VisitasBloc extends Bloc<VisitasEvent, VisitasState> {
-  VisitasBloc(this._repository) : super(VisitasCargando()) {
+  VisitasBloc(this._repository, this._verificacionRepository)
+      : super(VisitasCargando()) {
     on<CargarVisitas>(_onCargarVisitas);
     on<SincronizarVisitas>(_onSincronizarVisitas);
   }
 
   final VisitsRepository _repository;
+  final VerificacionRepository _verificacionRepository;
 
   Future<void> _onCargarVisitas(
     CargarVisitas event,
@@ -25,11 +28,25 @@ class VisitasBloc extends Bloc<VisitasEvent, VisitasState> {
     try {
       final resultado =
           await _repository.obtenerVisitasPorGeologo(event.idGeologo);
-      final programadas =
+
+      final todasProgramadas =
           resultado.visitas[EstadoVisita.programada] ?? [];
-      final borrador = resultado.visitas[EstadoVisita.enProceso] ?? [];
       final completadas =
           resultado.visitas[EstadoVisita.realizada] ?? [];
+
+      final programadas = <Visita>[];
+      final borrador = <Visita>[];
+
+      for (final visita in todasProgramadas) {
+        final verificacion =
+            await _verificacionRepository.obtenerVerificacion(visita.id);
+        if (verificacion != null) {
+          borrador.add(visita);
+        } else {
+          programadas.add(visita);
+        }
+      }
+
       emit(VisitasCargadas(
         programadas: programadas,
         borrador: borrador,

--- a/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
+++ b/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
@@ -10,6 +10,8 @@ import '../../dominio/entidades/visita.dart';
 import '../bloc/visitas_bloc.dart';
 import '../componentes/pestana_personalizada.dart';
 import '../componentes/visita_card.dart';
+import '../../../flujo_visita/datos/fuentes_datos/verificacion_local_data_source.dart';
+import '../../../flujo_visita/datos/repositorios/verificacion_repository_impl.dart';
 
 /// Página que muestra las visitas organizadas en pestañas.
 class VisitasTabsPage extends StatefulWidget {
@@ -31,7 +33,11 @@ class _VisitasTabsPageState extends State<VisitasTabsPage> {
     final remoto = VisitsRemoteDataSource(ClienteHttp(token: auth.token!));
     final local = VisitsLocalDataSource(ServicioBdLocal());
     final repo = VisitsRepositoryImpl(remoto, local);
-    _bloc = VisitasBloc(repo)..add(CargarVisitas(auth.usuario!.id));
+    final verificacionLocal =
+        VerificacionLocalDataSource(ServicioBdLocal());
+    final verificacionRepo = VerificacionRepositoryImpl(verificacionLocal);
+    _bloc = VisitasBloc(repo, verificacionRepo)
+      ..add(CargarVisitas(auth.usuario!.id));
     _bloc.stream.listen((state) {
       if (state is VisitasCargadas && state.advertencia != null) {
         WidgetsBinding.instance.addPostFrameCallback((_) {


### PR DESCRIPTION
## Summary
- Separa las visitas programadas en dos listas según tengan verificación en curso
- Construye el `VisitasBloc` con repositorio de verificaciones local
- Inicializa el repositorio de verificación en la pantalla de pestañas

## Testing
- `dart format lib/features/visitas/presentacion/bloc/visitas_bloc.dart lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa60dcccfc83319844af65ea7554cd