### PR TITLE
feat: compute provider progress from verification

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -126,7 +126,9 @@ class _ActividadMineraReinfoPaginaState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Actividad minera (REINFO)')),
+      appBar: AppBar(
+          title: const Text(
+              'Actividad Minera Declarada por el Proveedor de Mineral en el Comprobante de Recepción de Datos para el REINFO')),
       body: Form(
         key: _formKey,
         child: SingleChildScrollView(


### PR DESCRIPTION
## Summary
- load provider form from stored verification and compute step progress
- show dynamic progress in provider page and persist after saving
- rename REINFO activity page title

## Testing
- `dart format lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6898274c8331ba949ea0ea3c3c9c