### PR TITLE
Refactor nombre de tipos de actividad

### DIFF
--- a/lib/core/servicios/servicio_bd_local.dart
+++ b/lib/core/servicios/servicio_bd_local.dart
@@ -27,7 +27,7 @@ class ServicioBdLocal {
       'realizar_verificacion';
 
   static const _nombreBd = 'vinculacion.db';
-  static const _versionBd = 3;
+  static const _versionBd = 4;
 
   Database? _db;
 
@@ -61,8 +61,8 @@ class ServicioBdLocal {
         ''');
         await db.execute('''
           CREATE TABLE $nombreTablaTipoActividad(
-            codigo INTEGER PRIMARY KEY,
-            descripcion TEXT
+            id INTEGER PRIMARY KEY,
+            nombre TEXT
           );
         ''');
         await db.execute('''
@@ -95,7 +95,7 @@ class ServicioBdLocal {
           await db.execute('''
             CREATE TABLE IF NOT EXISTS $nombreTablaTipoActividad(
               id INTEGER PRIMARY KEY,
-              descripcion TEXT
+              nombre TEXT
             );
           ''');
           await db.execute('''
@@ -112,6 +112,16 @@ class ServicioBdLocal {
               data TEXT
             );
           ''');
+        }
+        if (oldVersion < 4) {
+          try {
+            await db.execute(
+                'ALTER TABLE $nombreTablaTipoActividad RENAME COLUMN descripcion TO nombre;');
+          } catch (_) {}
+          try {
+            await db.execute(
+                'ALTER TABLE $nombreTablaTipoActividad RENAME COLUMN codigo TO id;');
+          } catch (_) {}
         }
       },
     );

--- a/lib/features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart
+++ b/lib/features/actividad/datos/fuentes_datos/tipo_actividad_local_data_source.dart
@@ -19,7 +19,7 @@ class TipoActividadLocalDataSource {
       for (final tipo in tipos) {
         await _bdLocal.insert(_tabla, {
           'id': tipo.id,
-          'descripcion': tipo.descripcion,
+          'nombre': tipo.nombre,
         });
       }
     } on DatabaseException catch (e) {
@@ -35,7 +35,7 @@ class TipoActividadLocalDataSource {
       return rows
           .map((row) => TipoActividad(
                 id: row['id'] as int,
-                descripcion: row['descripcion'] as String,
+                nombre: row['nombre'] as String,
               ))
           .toList();
     } on DatabaseException catch (e) {

--- a/lib/features/actividad/dominio/entidades/tipo_actividad.dart
+++ b/lib/features/actividad/dominio/entidades/tipo_actividad.dart
@@ -3,22 +3,22 @@ class TipoActividad {
   /// Identificador único del tipo.
   final int id;
 
-  /// Descripción legible del tipo.
-  final String descripcion;
+  /// Nombre legible del tipo.
+  final String nombre;
 
   /// Crea una instancia de [TipoActividad].
-  const TipoActividad({required this.id, required this.descripcion});
+  const TipoActividad({required this.id, required this.nombre});
 
   /// Construye un [TipoActividad] a partir de un mapa JSON.
   factory TipoActividad.fromJson(Map<String, dynamic> json) => TipoActividad(
         id: json['Id'] as int,
-        descripcion: json['Descripcion'] as String,
+        nombre: json['Nombre'] as String,
       );
 
   /// Convierte el [TipoActividad] en un mapa JSON.
   Map<String, dynamic> toJson() => {
         'Id': id,
-        'Descripcion': descripcion,
+        'Nombre': nombre,
       };
 }
 
@@ -27,31 +27,25 @@ class SubTipoActividad {
   /// Identificador único del sub tipo.
   final int id;
 
-  /// Descripción legible del sub tipo.
-  final String descripcion;
-
-  /// Identificador del tipo de actividad al que pertenece.
-  final int idTipoActividad;
+  /// Nombre legible del sub tipo.
+  final String nombre;
 
   /// Crea una instancia de [SubTipoActividad].
   const SubTipoActividad({
     required this.id,
-    required this.descripcion,
-    required this.idTipoActividad,
+    required this.nombre,
   });
 
   /// Construye un [SubTipoActividad] a partir de un mapa JSON.
   factory SubTipoActividad.fromJson(Map<String, dynamic> json) => SubTipoActividad(
         id: json['Id'] as int,
-        descripcion: json['Descripcion'] as String,
-        idTipoActividad: json['IdTipoActividad'] as int,
+        nombre: json['Nombre'] as String,
       );
 
   /// Convierte el [SubTipoActividad] en un mapa JSON.
   Map<String, dynamic> toJson() => {
         'Id': id,
-        'Descripcion': descripcion,
-        'IdTipoActividad': idTipoActividad,
+        'Nombre': nombre,
       };
 }
 

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
@@ -88,7 +88,7 @@ class _ActividadMineraIgafomPaginaState
       _subTipoSeleccionado = null;
       _subTiposDisponibles = _mapaSubTipos[tipo?.id] ?? [];
       if (tipo != null) {
-        final desc = tipo.descripcion.toLowerCase();
+        final desc = tipo.nombre.toLowerCase();
         if (desc.contains('beneficio')) {
           _labelSubTipo = 'Tipo de Beneficio';
         } else if (desc.contains('explot')) {
@@ -143,7 +143,7 @@ class _ActividadMineraIgafomPaginaState
                 items: _tipos
                     .map((e) => DropdownMenuItem(
                           value: e,
-                          child: Text(e.descripcion),
+                          child: Text(e.nombre),
                         ))
                     .toList(),
                 onChanged: _onTipoChanged,

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -88,7 +88,7 @@ class _ActividadMineraReinfoPaginaState
       _subTipoSeleccionado = null;
       _subTiposDisponibles = _mapaSubTipos[tipo?.id] ?? [];
       if (tipo != null) {
-        final desc = tipo.descripcion.toLowerCase();
+        final desc = tipo.nombre.toLowerCase();
         if (desc.contains('beneficio')) {
           _labelSubTipo = 'Tipo de Beneficio';
         } else if (desc.contains('explot')) {
@@ -143,7 +143,7 @@ class _ActividadMineraReinfoPaginaState
                 items: _tipos
                     .map((e) => DropdownMenuItem(
                           value: e,
-                          child: Text(e.descripcion),
+                          child: Text(e.nombre),
                         ))
                     .toList(),
                 onChanged: _onTipoChanged,

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
@@ -92,7 +92,7 @@ class _ActividadMineraVerificadaPaginaState
       _subTipoSeleccionado = null;
       _subTiposDisponibles = _mapaSubTipos[tipo?.id] ?? [];
       if (tipo != null) {
-        final desc = tipo.descripcion.toLowerCase();
+        final desc = tipo.nombre.toLowerCase();
         if (desc.contains('beneficio')) {
           _labelSubTipo = 'Tipo de Beneficio';
         } else if (desc.contains('explot')) {
@@ -149,7 +149,7 @@ class _ActividadMineraVerificadaPaginaState
                 items: _tipos
                     .map((e) => DropdownMenuItem(
                           value: e,
-                          child: Text(e.descripcion),
+                          child: Text(e.nombre),
                         ))
                     .toList(),
                 onChanged: _onTipoChanged,

--- a/test/features/actividad/actividad_minera_igafom_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_igafom_pagina_test.dart
@@ -32,8 +32,8 @@ class _FakeRepository extends ActividadRepositoryImpl {
 void main() {
   testWidgets('carga inicial de combos', (tester) async {
     final repo = _FakeRepository([
-      TipoActividad(id: 1, descripcion: 'Exploración'),
-      TipoActividad(id: 2, descripcion: 'Beneficio'),
+      TipoActividad(id: 1, nombre: 'Exploración'),
+      TipoActividad(id: 2, nombre: 'Beneficio'),
     ]);
 
     await tester.pumpWidget(MaterialApp(
@@ -50,8 +50,8 @@ void main() {
 
   testWidgets('cambia combo secundario al seleccionar otro tipo', (tester) async {
     final repo = _FakeRepository([
-      TipoActividad(id: 1, descripcion: 'Explotación'),
-      TipoActividad(id: 2, descripcion: 'Beneficio'),
+      TipoActividad(id: 1, nombre: 'Explotación'),
+      TipoActividad(id: 2, nombre: 'Beneficio'),
     ]);
 
     await tester.pumpWidget(MaterialApp(

--- a/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
@@ -32,8 +32,8 @@ class _FakeRepository extends ActividadRepositoryImpl {
 void main() {
   testWidgets('carga inicial de combos', (tester) async {
     final repo = _FakeRepository([
-      TipoActividad(id: 1, descripcion: 'Exploración'),
-      TipoActividad(id: 2, descripcion: 'Beneficio'),
+      TipoActividad(id: 1, nombre: 'Exploración'),
+      TipoActividad(id: 2, nombre: 'Beneficio'),
     ]);
 
     await tester.pumpWidget(MaterialApp(
@@ -50,8 +50,8 @@ void main() {
 
   testWidgets('cambia combo secundario al seleccionar otro tipo', (tester) async {
     final repo = _FakeRepository([
-      TipoActividad(id: 1, descripcion: 'Explotación'),
-      TipoActividad(id: 2, descripcion: 'Beneficio'),
+      TipoActividad(id: 1, nombre: 'Explotación'),
+      TipoActividad(id: 2, nombre: 'Beneficio'),
     ]);
 
     await tester.pumpWidget(MaterialApp(

--- a/test/features/actividad/actividad_minera_verificada_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_verificada_pagina_test.dart
@@ -32,8 +32,8 @@ class _FakeRepository extends ActividadRepositoryImpl {
 void main() {
   testWidgets('carga inicial de combos', (tester) async {
     final repo = _FakeRepository([
-      TipoActividad(id: 1, descripcion: 'Exploración'),
-      TipoActividad(id: 2, descripcion: 'Beneficio'),
+      TipoActividad(id: 1, nombre: 'Exploración'),
+      TipoActividad(id: 2, nombre: 'Beneficio'),
     ]);
 
     await tester.pumpWidget(MaterialApp(
@@ -53,8 +53,8 @@ void main() {
 
   testWidgets('cambia combo secundario al seleccionar otro tipo', (tester) async {
     final repo = _FakeRepository([
-      TipoActividad(id: 1, descripcion: 'Explotación'),
-      TipoActividad(id: 2, descripcion: 'Beneficio'),
+      TipoActividad(id: 1, nombre: 'Explotación'),
+      TipoActividad(id: 2, nombre: 'Beneficio'),
     ]);
 
     await tester.pumpWidget(MaterialApp(

--- a/test/features/actividad/actividad_repository_impl_test.dart
+++ b/test/features/actividad/actividad_repository_impl_test.dart
@@ -36,7 +36,7 @@ void main() {
     test('sincronizarTiposActividad guarda los datos obtenidos', () async {
       final remoto = _FakeRemote(RespuestaBase(
         codigoRespuesta: RespuestaBase.RESPUESTA_CORRECTA,
-        respuesta: [TipoActividad(id: 1, descripcion: 'Exploración')],
+        respuesta: [TipoActividad(id: 1, nombre: 'Exploración')],
       ));
       final local = _FakeLocal();
       final repo = ActividadRepositoryImpl(remoto, local);
@@ -44,7 +44,7 @@ void main() {
       await repo.sincronizarTiposActividad();
 
       expect(local.almacenados.length, 1);
-      expect(local.almacenados.first.descripcion, 'Exploración');
+      expect(local.almacenados.first.nombre, 'Exploración');
     });
 
     test('sincronizarTiposActividad limpia datos cuando hay error', () async {
@@ -53,7 +53,7 @@ void main() {
         mensajeError: 'fallo',
       ));
       final local = _FakeLocal();
-      local.almacenados = [TipoActividad(id: 1, descripcion: 'A')];
+      local.almacenados = [TipoActividad(id: 1, nombre: 'A')];
       final repo = ActividadRepositoryImpl(remoto, local);
 
       await repo.sincronizarTiposActividad();
@@ -64,7 +64,7 @@ void main() {
     test('obtenerTiposActividad retorna datos remotos y sincroniza locales', () async {
       final remoto = _FakeRemote(RespuestaBase(
         codigoRespuesta: RespuestaBase.RESPUESTA_CORRECTA,
-        respuesta: [TipoActividad(id: 1, descripcion: 'Exploración')],
+        respuesta: [TipoActividad(id: 1, nombre: 'Exploración')],
       ));
       final local = _FakeLocal();
       final repo = ActividadRepositoryImpl(remoto, local);
@@ -82,13 +82,13 @@ void main() {
         mensajeError: 'error remoto',
       ));
       final local = _FakeLocal();
-      local.almacenados = [TipoActividad(id: 2, descripcion: 'Beneficio')];
+      local.almacenados = [TipoActividad(id: 2, nombre: 'Beneficio')];
       final repo = ActividadRepositoryImpl(remoto, local);
 
       final result = await repo.obtenerTiposActividad();
 
       expect(result.advertencia, 'error remoto');
-      expect(result.tipos.first.descripcion, 'Beneficio');
+      expect(result.tipos.first.nombre, 'Beneficio');
     });
   });
 }

--- a/test/features/actividad/tipo_actividad_remote_data_source_test.dart
+++ b/test/features/actividad/tipo_actividad_remote_data_source_test.dart
@@ -16,8 +16,8 @@ void main() {
         final body = jsonEncode({
           'CodigoRespuesta': RespuestaBase.RESPUESTA_CORRECTA,
           'Respuesta': [
-            {'id': 1, 'descripcion': 'Exploración'},
-            {'id': 2, 'descripcion': 'Beneficio'},
+            {'Id': 1, 'Nombre': 'Exploración'},
+            {'Id': 2, 'Nombre': 'Beneficio'},
           ],
         });
         return http.Response(body, 200);
@@ -30,7 +30,7 @@ void main() {
       expect(respuesta.codigoRespuesta, RespuestaBase.RESPUESTA_CORRECTA);
       expect(respuesta.respuesta, isA<List<TipoActividad>>());
       expect(respuesta.respuesta!.length, 2);
-      expect(respuesta.respuesta!.first.descripcion, 'Exploración');
+      expect(respuesta.respuesta!.first.nombre, 'Exploración');
     });
 
     test('devuelve error cuando el servidor responde con código no 200', () async {


### PR DESCRIPTION
## Summary
- Cambié `descripcion` por `nombre` en `TipoActividad` y `SubTipoActividad` y actualicé la serialización.
- Actualicé acceso local y migración de la tabla `tipo_actividad` para usar la columna `nombre`.
- Ajusté páginas y pruebas que mostraban tipos de actividad para usar el nuevo campo `nombre`.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6f9143a4833181d73bf63ded0f12