### PR TITLE
feat: store actividad reinfo in verificacion

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -61,7 +61,13 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             TipoActividadRemoteDataSource(ClienteHttp(token: auth.token!)),
             TipoActividadLocalDataSource(ServicioBdLocal()),
           );
-          return ActividadMineraReinfoPagina(repository: repo);
+          final verificacionRepo = VerificacionRepositoryImpl(
+            VerificacionLocalDataSource(ServicioBdLocal()),
+          );
+          return ActividadMineraReinfoPagina(
+            repository: repo,
+            verificacionRepository: verificacionRepo,
+          );
         },
       ),
       GoRoute(


### PR DESCRIPTION
## Summary
- inject VerificacionRepository into ActividadMineraReinfoPagina and preload stored data
- persist actividad into RealizarVerificacionDto via VerificacionRepository
- cover persistence and prefill with widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa723ba6648331a3547e959fe87d68