### PR TITLE
Route REINFO activity through IGAFOM

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
@@ -16,10 +16,14 @@ class ActividadMineraIgafomPagina extends StatefulWidget {
   const ActividadMineraIgafomPagina({
     super.key,
     required this.repository,
+    this.actividadReinfo,
   });
 
   /// Repositorio usado para obtener los tipos de actividad.
   final ActividadRepositoryImpl repository;
+
+  /// Actividad registrada en el REINFO que se pasa al flujo.
+  final Actividad? actividadReinfo;
 
   @override
   State<ActividadMineraIgafomPagina> createState() =>
@@ -120,7 +124,10 @@ class _ActividadMineraIgafomPaginaState
       zonaUTM: int.tryParse(_zonaController.text),
       descripcion: null,
     );
-    context.push('/flujo-visita/datos-proveedor', extra: actividad);
+    context.push(
+      '/flujo-visita/registro-fotografico',
+      extra: {'actividad': actividad, 'flagMedicionCapacidad': false},
+    );
   }
 
   @override

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -221,7 +221,7 @@ class _ActividadMineraReinfoPaginaState
       );
     }
     await widget.verificacionRepository.guardarVerificacion(dto);
-    context.push('/flujo-visita/datos-proveedor', extra: actividad);
+    context.push('/flujo-visita/actividad-igafom', extra: actividad);
   }
 
   @override

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -106,7 +106,11 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             TipoActividadRemoteDataSource(ClienteHttp(token: auth.token!)),
             TipoActividadLocalDataSource(ServicioBdLocal()),
           );
-          return ActividadMineraIgafomPagina(repository: repo);
+          final actividad = state.extra as Actividad?;
+          return ActividadMineraIgafomPagina(
+            repository: repo,
+            actividadReinfo: actividad,
+          );
         },
       ),
       GoRoute(

--- a/test/features/actividad/actividad_minera_igafom_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_igafom_pagina_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
 import 'package:veta_dorada_vinculacion_mobile/core/servicios/servicio_bd_local.dart';
@@ -81,6 +82,45 @@ void main() {
     expect(find.text('Gravimétrico'), findsOneWidget);
     expect(find.text('Lixiviación'), findsOneWidget);
     expect(find.text('Aluvial'), findsNothing);
+  });
+
+  testWidgets('navega a registro fotografico al guardar', (tester) async {
+    final repo = _FakeRepository([
+      TipoActividad(id: 1, nombre: 'Explotación'),
+    ]);
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => ActividadMineraIgafomPagina(
+            repository: repo,
+          ),
+        ),
+        GoRoute(
+          path: '/flujo-visita/registro-fotografico',
+          builder: (context, state) => const Placeholder(),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<TipoActividad>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Explotación').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Aluvial').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Guardar'));
+    await tester.pumpAndSettle();
+
+    expect(router.location, '/flujo-visita/registro-fotografico');
   });
 }
 

--- a/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:veta_dorada_vinculacion_mobile/core/red/cliente_http.dart';
 import 'package:veta_dorada_vinculacion_mobile/core/servicios/servicio_bd_local.dart';
@@ -155,6 +156,47 @@ void main() {
     expect(saved!.actividades, hasLength(1));
     expect(saved.actividades.first.idTipoActividad, 1);
     expect(saved.actividades.first.idSubTipoActividad, 1);
+  });
+
+  testWidgets('navega a actividad igafom al guardar', (tester) async {
+    final repo = _FakeRepository([
+      TipoActividad(id: 1, nombre: 'Explotación'),
+    ]);
+    final verificacionRepo = _MockVerificacionRepository();
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => ActividadMineraReinfoPagina(
+            repository: repo,
+            verificacionRepository: verificacionRepo,
+          ),
+        ),
+        GoRoute(
+          path: '/flujo-visita/actividad-igafom',
+          builder: (context, state) => const Placeholder(),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<TipoActividad>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Explotación').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Aluvial').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Guardar'));
+    await tester.pumpAndSettle();
+
+    expect(router.location, '/flujo-visita/actividad-igafom');
   });
 
   testWidgets('precarga datos si existe actividad previa', (tester) async {


### PR DESCRIPTION
## Summary
- Redirect REINFO activity save to IGAFOM route and pass the activity along
- Allow IGAFOM route to receive previous activity and continue to photographic record
- Add navigation flow tests for REINFO and IGAFOM pages

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa73d2dfd88331a749fe4370b572f1