### PR TITLE
refactor: pass idVisita to reinfo page

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -24,6 +24,7 @@ class ActividadMineraReinfoPagina extends StatefulWidget {
     super.key,
     required this.repository,
     required this.verificacionRepository,
+    required this.idVisita,
   });
 
   /// Repositorio usado para obtener los tipos de actividad.
@@ -31,6 +32,9 @@ class ActividadMineraReinfoPagina extends StatefulWidget {
 
   /// Repositorio para persistir la información de la verificación.
   final VerificacionRepository verificacionRepository;
+
+  /// Identificador de la visita asociada a la verificación.
+  final int idVisita;
 
   @override
   State<ActividadMineraReinfoPagina> createState() =>
@@ -47,7 +51,6 @@ class _ActividadMineraReinfoPaginaState
   List<String> _subTiposDisponibles = [];
   String _labelSubTipo = 'Sub Tipo';
 
-  static const int _idVisita = 0;
 
   final Map<int, List<String>> _mapaSubTipos = {
     // Opciones de ejemplo para los sub tipos dependiendo del tipo.
@@ -90,7 +93,7 @@ class _ActividadMineraReinfoPaginaState
 
   Future<void> _inicializar() async {
     final dto =
-        await widget.verificacionRepository.obtenerVerificacion(_idVisita);
+        await widget.verificacionRepository.obtenerVerificacion(widget.idVisita);
     final resultado = await widget.repository.obtenerTiposActividad();
     _tipos = resultado.tipos;
 
@@ -167,11 +170,11 @@ class _ActividadMineraReinfoPaginaState
     );
 
     var dto =
-        await widget.verificacionRepository.obtenerVerificacion(_idVisita);
+        await widget.verificacionRepository.obtenerVerificacion(widget.idVisita);
     if (dto == null) {
       dto = RealizarVerificacionDto(
         idVerificacion: 0,
-        idVisita: _idVisita,
+        idVisita: widget.idVisita,
         idUsuario: 0,
         fechaInicioMovil: DateTime.now(),
         fechaFinMovil: DateTime.now(),

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -65,9 +65,11 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final verificacionRepo = VerificacionRepositoryImpl(
             VerificacionLocalDataSource(ServicioBdLocal()),
           );
+          final idVisita = state.extra as int;
           return ActividadMineraReinfoPagina(
             repository: repo,
             verificacionRepository: verificacionRepo,
+            idVisita: idVisita,
           );
         },
       ),

--- a/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
@@ -91,6 +91,7 @@ void main() {
       home: ActividadMineraReinfoPagina(
         repository: repo,
         verificacionRepository: verificacionRepo,
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();
@@ -119,6 +120,7 @@ void main() {
       home: ActividadMineraReinfoPagina(
         repository: repo,
         verificacionRepository: verificacionRepo,
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();
@@ -147,6 +149,7 @@ void main() {
       home: ActividadMineraReinfoPagina(
         repository: repo,
         verificacionRepository: verificacionRepo,
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();
@@ -177,6 +180,7 @@ void main() {
       home: ActividadMineraReinfoPagina(
         repository: repo,
         verificacionRepository: verificacionRepo,
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();
@@ -215,6 +219,7 @@ void main() {
       home: ActividadMineraReinfoPagina(
         repository: repo,
         verificacionRepository: verificacionRepo,
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();
@@ -254,6 +259,7 @@ void main() {
           builder: (context, state) => ActividadMineraReinfoPagina(
             repository: repo,
             verificacionRepository: verificacionRepo,
+            idVisita: 0,
           ),
         ),
         GoRoute(
@@ -341,6 +347,7 @@ void main() {
       home: ActividadMineraReinfoPagina(
         repository: repo,
         verificacionRepository: verificacionRepo,
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- require `idVisita` for `ActividadMineraReinfoPagina`
- use provided visit id when loading and saving verification
- update router and tests to pass the visit id

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8a8d36b08331874608b195b02c6f