### PR TITLE
Add verification progress calculation

### DIFF
--- a/lib/features/flujo_visita/dominio/calcular_avance.dart
+++ b/lib/features/flujo_visita/dominio/calcular_avance.dart
@@ -1,0 +1,32 @@
+import 'entidades/realizar_verificacion_dto.dart';
+
+/// Número total de pasos del flujo de verificación.
+const int totalPasosVerificacion = 9;
+
+/// Calcula el avance del flujo de verificación basado en el
+/// contenido del [dto]. Retorna un valor entre 0 y 1.
+double calcularAvance(RealizarVerificacionDto dto) {
+  var count = 0;
+  if (dto.actividades.isNotEmpty) count++;
+  if (dto.descripcion.coordenadas.isNotEmpty ||
+      dto.descripcion.zona.isNotEmpty ||
+      dto.descripcion.actividad.isNotEmpty ||
+      dto.descripcion.equipos.isNotEmpty ||
+      dto.descripcion.trabajadores.isNotEmpty ||
+      dto.descripcion.condicionesLaborales.isNotEmpty) {
+    count++;
+  }
+  if (dto.evaluacion.idCondicionProspecto.isNotEmpty ||
+      (dto.evaluacion.anotacion?.isNotEmpty ?? false)) {
+    count++;
+  }
+  if (dto.estimacion.capacidadDiaria > 0 ||
+      dto.estimacion.diasOperacion > 0 ||
+      dto.estimacion.produccionEstimada > 0) {
+    count++;
+  }
+  if (dto.fotos.isNotEmpty) count++;
+  if (dto.proveedorSnapshot.nombre.isNotEmpty) count++;
+
+  return count / totalPasosVerificacion;
+}

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
@@ -13,6 +13,7 @@ import '../../dominio/entidades/foto.dart';
 import '../../dominio/entidades/proveedor_snapshot.dart';
 import '../../dominio/entidades/realizar_verificacion_dto.dart';
 import '../../dominio/repositorios/verificacion_repository.dart';
+import '../../dominio/calcular_avance.dart';
 
 /// Página para registrar una actividad minera verificada por la autoridad.
 ///
@@ -70,6 +71,9 @@ class _ActividadMineraVerificadaPaginaState
   final TextEditingController _distritoController = TextEditingController();
   final TextEditingController _derechoMineroController =
       TextEditingController();
+
+  static const int _totalPasos = totalPasosVerificacion;
+  double _avance = 0;
 
   @override
   void initState() {
@@ -135,6 +139,8 @@ class _ActividadMineraVerificadaPaginaState
       _comp01NorteController.text = actividad.utmNorte.toString();
       _derechoMineroController.text = actividad.derechoMinero ?? '';
     }
+
+    _avance = dto != null ? calcularAvance(dto) : 0;
 
     if (mounted) {
       setState(() {});
@@ -237,6 +243,7 @@ class _ActividadMineraVerificadaPaginaState
       );
     }
     await widget.verificacionRepository.guardarVerificacion(dto);
+    _avance = calcularAvance(dto);
     final actividadGuardada =
         dto.actividades.firstWhere((a) => a.origen == Origen.verificada);
     if (!mounted) return;
@@ -257,6 +264,12 @@ class _ActividadMineraVerificadaPaginaState
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
+              Center(
+                  child: Text('${(_avance * _totalPasos).round()} de '
+                      '$_totalPasos')),
+              const SizedBox(height: 8),
+              LinearProgressIndicator(value: _avance),
+              const SizedBox(height: 24),
               DropdownButtonFormField<TipoActividad>(
                 decoration: const InputDecoration(
                   labelText: 'Tipo de actividad',

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -132,10 +132,12 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final extras = state.extra! as Map<String, dynamic>;
           final actividad = extras['actividad'] as Actividad;
           final flag = extras['flagMedicionCapacidad'] as bool;
+          final dto = extras['dto'] as RealizarVerificacionDto;
           return RegistroFotograficoVerificacionPagina(
             actividad: actividad,
             flagMedicionCapacidad: flag,
             flowRepository: flowRepository,
+            dto: dto,
           );
         },
       ),


### PR DESCRIPTION
## Summary
- add `calcularAvance` utility to compute verification flow progress
- show and update progress indicators across verification pages
- pass verification DTO through router to support progress tracking

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8b97cb78833194b85b2ad0ab529f