### PR TITLE
test: update route for actividad verification navigation

### DIFF
--- a/test/features/actividad/actividad_minera_igafom_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_igafom_pagina_test.dart
@@ -124,7 +124,7 @@ void main() {
           ),
         ),
         GoRoute(
-          path: '/flujo-visita/registro-fotografico',
+          path: '/flujo-visita/actividad-verificada',
           builder: (context, state) => const Placeholder(),
         ),
       ],
@@ -146,7 +146,7 @@ void main() {
     await tester.tap(find.text('Guardar'));
     await tester.pumpAndSettle();
 
-    expect(router.location, '/flujo-visita/registro-fotografico');
+    expect(router.location, '/flujo-visita/actividad-verificada');
   });
 }
 


### PR DESCRIPTION
## Summary
- adjust actividad minera igafom test to expect navigation to `/flujo-visita/actividad-verificada`

## Testing
- `flutter test test/features/actividad/actividad_minera_igafom_pagina_test.dart` *(fails: command not found)*
- `dart test test/features/actividad/actividad_minera_igafom_pagina_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa905aeebc833195b3e68d40612e9c