### PR TITLE
feat: pass visit id through activity pages

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
@@ -24,6 +24,7 @@ class ActividadMineraIgafomPagina extends StatefulWidget {
     super.key,
     required this.repository,
     required this.verificacionRepository,
+    required this.idVisita,
     this.actividadReinfo,
   });
 
@@ -32,6 +33,9 @@ class ActividadMineraIgafomPagina extends StatefulWidget {
 
   /// Repositorio para persistir la información de la verificación.
   final VerificacionRepository verificacionRepository;
+
+  /// Identificador de la visita asociada a la verificación.
+  final int idVisita;
 
   /// Actividad registrada en el REINFO que se pasa al flujo.
   final Actividad? actividadReinfo;
@@ -50,8 +54,6 @@ class _ActividadMineraIgafomPaginaState
   String? _subTipoSeleccionado;
   List<String> _subTiposDisponibles = [];
   String _labelSubTipo = 'Sub Tipo';
-
-  static const int _idVisita = 0;
 
   final Map<int, List<String>> _mapaSubTipos = {
     // Opciones de ejemplo para los sub tipos dependiendo del tipo.
@@ -94,7 +96,7 @@ class _ActividadMineraIgafomPaginaState
 
   Future<void> _inicializar() async {
     final dto =
-        await widget.verificacionRepository.obtenerVerificacion(_idVisita);
+        await widget.verificacionRepository.obtenerVerificacion(widget.idVisita);
     final resultado = await widget.repository.obtenerTiposActividad();
     _tipos = resultado.tipos;
 
@@ -181,11 +183,11 @@ class _ActividadMineraIgafomPaginaState
     );
 
     var dto =
-        await widget.verificacionRepository.obtenerVerificacion(_idVisita);
+        await widget.verificacionRepository.obtenerVerificacion(widget.idVisita);
     if (dto == null) {
       dto = RealizarVerificacionDto(
         idVerificacion: 0,
-        idVisita: _idVisita,
+        idVisita: widget.idVisita,
         idUsuario: 0,
         fechaInicioMovil: DateTime.now(),
         fechaFinMovil: DateTime.now(),
@@ -242,7 +244,10 @@ class _ActividadMineraIgafomPaginaState
     if (!mounted) return;
     context.push(
       '/flujo-visita/actividad-verificada',
-      extra: false,
+      extra: {
+        'flagMedicionCapacidad': false,
+        'idVisita': widget.idVisita,
+      },
     );
   }
 

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -224,7 +224,8 @@ class _ActividadMineraReinfoPaginaState
       );
     }
     await widget.verificacionRepository.guardarVerificacion(dto);
-    context.push('/flujo-visita/actividad-igafom', extra: actividad);
+    context.push('/flujo-visita/actividad-igafom',
+        extra: {'actividad': actividad, 'idVisita': widget.idVisita});
   }
 
   @override

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
@@ -26,6 +26,7 @@ class ActividadMineraVerificadaPagina extends StatefulWidget {
     required this.repository,
     required this.verificacionRepository,
     required this.flagMedicionCapacidad,
+    required this.idVisita,
   });
 
   /// Repositorio usado para obtener los tipos de actividad.
@@ -36,6 +37,9 @@ class ActividadMineraVerificadaPagina extends StatefulWidget {
 
   /// Indica si la visita requiere medición de capacidad.
   final bool flagMedicionCapacidad;
+
+  /// Identificador de la visita asociada a la verificación.
+  final int idVisita;
 
   @override
   State<ActividadMineraVerificadaPagina> createState() =>
@@ -51,8 +55,6 @@ class _ActividadMineraVerificadaPaginaState
   String? _subTipoSeleccionado;
   List<String> _subTiposDisponibles = [];
   String _labelSubTipo = 'Sub Tipo';
-
-  static const int _idVisita = 0;
 
   final Map<int, List<String>> _mapaSubTipos = {
     // Opciones de ejemplo para los sub tipos dependiendo del tipo.
@@ -97,8 +99,8 @@ class _ActividadMineraVerificadaPaginaState
   }
 
   Future<void> _inicializar() async {
-    final dto =
-        await widget.verificacionRepository.obtenerVerificacion(_idVisita);
+    final dto = await widget.verificacionRepository
+        .obtenerVerificacion(widget.idVisita);
     final resultado = await widget.repository.obtenerTiposActividad();
     _tipos = resultado.tipos;
 
@@ -187,12 +189,12 @@ class _ActividadMineraVerificadaPaginaState
       derechoMinero: _derechoMineroController.text,
     );
 
-    var dto =
-        await widget.verificacionRepository.obtenerVerificacion(_idVisita);
+    var dto = await widget.verificacionRepository
+        .obtenerVerificacion(widget.idVisita);
     if (dto == null) {
       dto = RealizarVerificacionDto(
         idVerificacion: 0,
-        idVisita: _idVisita,
+        idVisita: widget.idVisita,
         idUsuario: 0,
         fechaInicioMovil: DateTime.now(),
         fechaFinMovil: DateTime.now(),

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -84,11 +84,14 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final verificacionRepo = VerificacionRepositoryImpl(
             VerificacionLocalDataSource(ServicioBdLocal()),
           );
-          final flag = state.extra as bool? ?? false;
+          final extras = state.extra! as Map<String, dynamic>;
+          final flag = extras['flagMedicionCapacidad'] as bool? ?? false;
+          final idVisita = extras['idVisita'] as int;
           return ActividadMineraVerificadaPagina(
             repository: repo,
             verificacionRepository: verificacionRepo,
             flagMedicionCapacidad: flag,
+            idVisita: idVisita,
           );
         },
       ),
@@ -118,10 +121,13 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final verificacionRepo = VerificacionRepositoryImpl(
             VerificacionLocalDataSource(ServicioBdLocal()),
           );
-          final actividad = state.extra as Actividad?;
+          final extras = state.extra! as Map<String, dynamic>;
+          final actividad = extras['actividad'] as Actividad?;
+          final idVisita = extras['idVisita'] as int;
           return ActividadMineraIgafomPagina(
             repository: repo,
             verificacionRepository: verificacionRepo,
+            idVisita: idVisita,
             actividadReinfo: actividad,
           );
         },

--- a/test/features/actividad/actividad_minera_igafom_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_igafom_pagina_test.dart
@@ -60,6 +60,7 @@ void main() {
       home: ActividadMineraIgafomPagina(
         repository: repo,
         verificacionRepository: _FakeVerificacionRepository(),
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();
@@ -81,6 +82,7 @@ void main() {
       home: ActividadMineraIgafomPagina(
         repository: repo,
         verificacionRepository: _FakeVerificacionRepository(),
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();
@@ -121,6 +123,7 @@ void main() {
           builder: (context, state) => ActividadMineraIgafomPagina(
             repository: repo,
             verificacionRepository: _FakeVerificacionRepository(),
+            idVisita: 0,
           ),
         ),
         GoRoute(

--- a/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
@@ -264,10 +264,17 @@ void main() {
         ),
         GoRoute(
           path: '/flujo-visita/actividad-igafom',
-          builder: (context, state) => ActividadMineraIgafomPagina(
-            repository: repo,
-            actividadReinfo: state.extra as Actividad?,
-          ),
+          builder: (context, state) {
+            final extras = state.extra! as Map<String, dynamic>;
+            final actividad = extras['actividad'] as Actividad?;
+            final idVisita = extras['idVisita'] as int;
+            return ActividadMineraIgafomPagina(
+              repository: repo,
+              verificacionRepository: verificacionRepo,
+              idVisita: idVisita,
+              actividadReinfo: actividad,
+            );
+          },
         ),
       ],
     );

--- a/test/features/actividad/actividad_minera_verificada_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_verificada_pagina_test.dart
@@ -55,6 +55,7 @@ void main() {
         repository: repo,
         verificacionRepository: _FakeVerificacionRepository(),
         flagMedicionCapacidad: false,
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();
@@ -77,6 +78,7 @@ void main() {
         repository: repo,
         verificacionRepository: _FakeVerificacionRepository(),
         flagMedicionCapacidad: false,
+        idVisita: 0,
       ),
     ));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- plumb visit identifier through IGAFOM and verified activity pages
- forward `idVisita` in app router and flow navigation
- adjust tests for new route extras

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9180f0bc8331847b4e753eac8c6d