### PR TITLE
Persist verification description

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
@@ -5,6 +5,7 @@ import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../dominio/entidades/descripcion_actividad_verificada.dart';
 import '../../dominio/entidades/descripcion.dart';
 import '../../dominio/repositorios/flow_repository.dart';
+import '../../dominio/repositorios/verificacion_repository.dart';
 import '../../dominio/entidades/realizar_verificacion_dto.dart';
 import '../../dominio/calcular_avance.dart';
 
@@ -18,12 +19,14 @@ class DescripcionActividadMineraVerificadaPagina extends StatefulWidget {
     required this.actividad,
     required this.flagMedicionCapacidad,
     required this.flowRepository,
+    required this.verificacionRepository,
     required this.dto,
   });
 
   final Actividad actividad;
   final bool flagMedicionCapacidad;
   final FlowRepository flowRepository;
+  final VerificacionRepository verificacionRepository;
   final RealizarVerificacionDto dto;
 
   @override
@@ -102,6 +105,7 @@ class _DescripcionActividadMineraVerificadaPaginaState
         fotos: widget.dto.fotos,
         idempotencyKey: widget.dto.idempotencyKey,
       );
+      await widget.verificacionRepository.guardarVerificacion(dtoActualizado);
       _avance = calcularAvance(dtoActualizado);
       if (!mounted) return;
       setState(() {});

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -102,10 +102,14 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final actividad = extras['actividad'] as Actividad;
           final flag = extras['flagMedicionCapacidad'] as bool;
           final dto = extras['dto'] as RealizarVerificacionDto;
+          final verificacionRepo = VerificacionRepositoryImpl(
+            VerificacionLocalDataSource(ServicioBdLocal()),
+          );
           return DescripcionActividadMineraVerificadaPagina(
             actividad: actividad,
             flagMedicionCapacidad: flag,
             flowRepository: flowRepository,
+            verificacionRepository: verificacionRepo,
             dto: dto,
           );
         },

--- a/test/features/actividad/descripcion_actividad_minera_verificada_pagina_test.dart
+++ b/test/features/actividad/descripcion_actividad_minera_verificada_pagina_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/dominio/entidades/actividad.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/actividad/dominio/enums/origen.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/completar_visita_comando.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/descripcion.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/descripcion_actividad_verificada.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/evaluacion.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/estimacion.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/foto.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/proveedor_snapshot.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/realizar_verificacion_dto.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/registro_fotografico.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/repositorios/flow_repository.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/repositorios/verificacion_repository.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart';
+
+class _FakeFlowRepository implements FlowRepository {
+  DescripcionActividadVerificada? descripcion;
+
+  @override
+  Future<void> guardarDescripcionActividadVerificada(
+      DescripcionActividadVerificada descripcion) async {
+    this.descripcion = descripcion;
+  }
+
+  @override
+  Future<DescripcionActividadVerificada?>
+      obtenerDescripcionActividadVerificada() async => descripcion;
+
+  @override
+  Future<void> guardarEvaluacion(Evaluacion evaluacion) async {}
+
+  @override
+  Future<Evaluacion?> obtenerEvaluacion() async => null;
+
+  @override
+  Future<void> guardarEstimacion(Estimacion estimacion) async {}
+
+  @override
+  Future<Estimacion?> obtenerEstimacion() async => null;
+
+  @override
+  Future<void> agregarFotoVerificacion(RegistroFotografico foto) async {}
+
+  @override
+  Future<void> eliminarFotoVerificacion(int index) async {}
+
+  @override
+  Future<List<RegistroFotografico>> obtenerFotosVerificacion() async => [];
+
+  @override
+  Future<void> completarFlujo(CompletarVisitaComando comando) async {}
+}
+
+class _MockVerificacionRepository implements VerificacionRepository {
+  RealizarVerificacionDto? savedDto;
+
+  @override
+  Future<void> guardarVerificacion(RealizarVerificacionDto dto) async {
+    savedDto = dto;
+  }
+
+  @override
+  Future<RealizarVerificacionDto?> obtenerVerificacion(int idVisita) async =>
+      savedDto;
+
+  @override
+  Future<List<int>> obtenerVisitasConVerificacion() async => [];
+}
+
+void main() {
+  testWidgets('guarda descripción en VerificacionRepository', (tester) async {
+    final actividad = const Actividad(
+      id: '1',
+      origen: Origen.verificada,
+      idTipoActividad: 1,
+      idSubTipoActividad: 1,
+      utmEste: 0,
+      utmNorte: 0,
+    );
+    final dto = RealizarVerificacionDto(
+      idVerificacion: 1,
+      idVisita: 1,
+      idUsuario: 1,
+      fechaInicioMovil: DateTime.now(),
+      fechaFinMovil: DateTime.now(),
+      proveedorSnapshot: const ProveedorSnapshot(
+        tipoPersona: '',
+        nombre: '',
+        inicioFormalizacion: false,
+      ),
+      actividades: const [],
+      descripcion: const Descripcion(
+        coordenadas: '',
+        zona: '',
+        actividad: '',
+        equipos: '',
+        trabajadores: '',
+        condicionesLaborales: '',
+      ),
+      evaluacion: const Evaluacion(idCondicionProspecto: '', anotacion: ''),
+      estimacion: const Estimacion(
+        capacidadDiaria: 0,
+        diasOperacion: 0,
+        produccionEstimada: 0,
+      ),
+      fotos: const <Foto>[],
+      idempotencyKey: '',
+    );
+
+    final flowRepo = _FakeFlowRepository();
+    final verificacionRepo = _MockVerificacionRepository();
+
+    final router = GoRouter(routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => DescripcionActividadMineraVerificadaPagina(
+          actividad: actividad,
+          flagMedicionCapacidad: false,
+          flowRepository: flowRepo,
+          verificacionRepository: verificacionRepo,
+          dto: dto,
+        ),
+      ),
+      GoRoute(
+        path: '/flujo-visita/registro-fotografico',
+        builder: (context, state) => const SizedBox.shrink(),
+      ),
+    ]);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.bySemanticsLabel('Coordenadas, ubicación geográfica y política'),
+        'coord');
+    await tester.enterText(
+        find.bySemanticsLabel('Zona de la labor minera'), 'zona');
+    await tester.enterText(
+        find.bySemanticsLabel('Actividad minera verificada'), 'act');
+    await tester.enterText(
+        find.bySemanticsLabel('Equipos y maquinaria'), 'equip');
+    await tester.enterText(
+        find.bySemanticsLabel('Trabajadores'), 'trab');
+    await tester.enterText(
+        find.bySemanticsLabel(
+            'Trabajo forzado/infantil, medio ambiente y seguridad'),
+        'seg');
+
+    await tester.tap(find.text('Siguiente'));
+    await tester.pumpAndSettle();
+
+    final saved = verificacionRepo.savedDto;
+    expect(saved, isNotNull);
+    expect(saved!.descripcion.coordenadas, 'coord');
+    expect(saved.descripcion.zona, 'zona');
+    expect(saved.descripcion.actividad, 'act');
+    expect(saved.descripcion.equipos, 'equip');
+    expect(saved.descripcion.trabajadores, 'trab');
+    expect(saved.descripcion.condicionesLaborales, 'seg');
+  });
+}
+


### PR DESCRIPTION
## Summary
- inject `VerificacionRepository` into description page
- save updated verification DTO when advancing
- supply repository via router and add widget test for persistence

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa946192f0833197809f3d06ccacbd