### PR TITLE
Preload evaluacion data and fetch conditions directly

### DIFF
--- a/lib/features/flujo_visita/datos/repositorios/general_repository.dart
+++ b/lib/features/flujo_visita/datos/repositorios/general_repository.dart
@@ -64,6 +64,15 @@ class GeneralRepository {
     }
   }
 
+  /// Obtiene las condiciones del prospecto para verificación directamente
+  /// desde la API.
+  Future<List<CondicionProspecto>>
+      obtenerCondicionesProspectoVerificacion() async {
+    final respuesta =
+        await _remoteDataSource.obtenerCondicionesProspectoVerificacion();
+    return respuesta.respuesta ?? [];
+  }
+
   /// Sincroniza los catálogos generales al inicio de la aplicación.
   ///
   /// Borra los datos existentes y descarga los registros más recientes desde

--- a/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
@@ -54,14 +54,24 @@ class _EvaluacionLaborPaginaState extends State<EvaluacionLaborPagina> {
   void initState() {
     super.initState();
     _dto = widget.dto;
+    _init();
+  }
+
+  Future<void> _init() async {
+    final previa =
+        await widget.verificacionRepository.obtenerVerificacion(widget.dto.idVisita);
+    if (previa != null) {
+      _dto = previa;
+    }
     _anotacionController.text = _dto.evaluacion.anotacion ?? '';
-    _cargarCondiciones();
+    await _cargarCondiciones();
   }
 
   Future<void> _cargarCondiciones() async {
-    final resultado = await widget.repository.obtenerCondicionesProspecto();
+    final condiciones =
+        await widget.repository.obtenerCondicionesProspectoVerificacion();
     setState(() {
-      _condiciones = resultado.condiciones;
+      _condiciones = condiciones;
       for (final cond in _condiciones) {
         if (cond.codigo == _dto.evaluacion.idCondicionProspecto) {
           _condicionSeleccionada = cond;


### PR DESCRIPTION
## Summary
- Add GeneralRepository method to fetch prospect conditions from remote source
- Preload stored verification and load conditions via new repository method in evaluation page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa98cddf988331967c3b49c5a03588