### PR TITLE
Navega a página de firma tras evaluación de labor

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
@@ -114,9 +114,9 @@ class _EvaluacionLaborPaginaState extends State<EvaluacionLaborPagina> {
     );
     await widget.verificacionRepository.guardarVerificacion(dtoActualizado);
     if (!mounted) return;
-    context.push('/flujo-visita/estimacion-produccion', extra: {
+    context.push('/flujo-visita/firma', extra: {
+      'actividad': widget.actividad,
       'flagMedicionCapacidad': widget.flagMedicionCapacidad,
-      'dto': dtoActualizado,
     });
   }
 


### PR DESCRIPTION
## Summary
- Redirige a `/flujo-visita/firma` desde la evaluación de labor
- Envía `actividad` y `flagMedicionCapacidad` en la navegación

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa9de4481483319d861814e8d1e0d1