### PR TITLE
feat: add estimation production navigation

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
@@ -25,6 +25,7 @@ class ActividadMineraIgafomPagina extends StatefulWidget {
     required this.repository,
     required this.verificacionRepository,
     required this.idVisita,
+    required this.flagEstimacionProduccion,
     this.actividadReinfo,
   });
 
@@ -36,6 +37,9 @@ class ActividadMineraIgafomPagina extends StatefulWidget {
 
   /// Identificador de la visita asociada a la verificación.
   final int idVisita;
+
+  /// Indica si la visita requiere estimación de producción.
+  final bool flagEstimacionProduccion;
 
   /// Actividad registrada en el REINFO que se pasa al flujo.
   final Actividad? actividadReinfo;
@@ -247,6 +251,7 @@ class _ActividadMineraIgafomPaginaState
       extra: {
         'flagMedicionCapacidad': false,
         'idVisita': widget.idVisita,
+        'flagEstimacionProduccion': widget.flagEstimacionProduccion,
       },
     );
   }

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -25,6 +25,7 @@ class ActividadMineraReinfoPagina extends StatefulWidget {
     required this.repository,
     required this.verificacionRepository,
     required this.idVisita,
+    required this.flagEstimacionProduccion,
   });
 
   /// Repositorio usado para obtener los tipos de actividad.
@@ -35,6 +36,9 @@ class ActividadMineraReinfoPagina extends StatefulWidget {
 
   /// Identificador de la visita asociada a la verificación.
   final int idVisita;
+
+  /// Indica si la visita requiere estimación de producción.
+  final bool flagEstimacionProduccion;
 
   @override
   State<ActividadMineraReinfoPagina> createState() =>
@@ -225,7 +229,11 @@ class _ActividadMineraReinfoPaginaState
     }
     await widget.verificacionRepository.guardarVerificacion(dto);
     context.push('/flujo-visita/actividad-igafom',
-        extra: {'actividad': actividad, 'idVisita': widget.idVisita});
+        extra: {
+          'actividad': actividad,
+          'idVisita': widget.idVisita,
+          'flagEstimacionProduccion': widget.flagEstimacionProduccion,
+        });
   }
 
   @override

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
@@ -26,6 +26,7 @@ class ActividadMineraVerificadaPagina extends StatefulWidget {
     required this.repository,
     required this.verificacionRepository,
     required this.flagMedicionCapacidad,
+    required this.flagEstimacionProduccion,
     required this.idVisita,
   });
 
@@ -37,6 +38,9 @@ class ActividadMineraVerificadaPagina extends StatefulWidget {
 
   /// Indica si la visita requiere medición de capacidad.
   final bool flagMedicionCapacidad;
+
+  /// Indica si la visita requiere estimación de producción.
+  final bool flagEstimacionProduccion;
 
   /// Identificador de la visita asociada a la verificación.
   final int idVisita;
@@ -252,6 +256,7 @@ class _ActividadMineraVerificadaPaginaState
     context.push('/flujo-visita/descripcion-actividad-verificada', extra: {
       'actividad': actividadGuardada,
       'flagMedicionCapacidad': widget.flagMedicionCapacidad,
+      'flagEstimacionProduccion': widget.flagEstimacionProduccion,
       'dto': dto,
     });
   }

--- a/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
@@ -17,12 +17,14 @@ class DescripcionActividadMineraVerificadaPagina extends StatefulWidget {
     super.key,
     required this.actividad,
     required this.flagMedicionCapacidad,
+    required this.flagEstimacionProduccion,
     required this.verificacionRepository,
     required this.dto,
   });
 
   final Actividad actividad;
   final bool flagMedicionCapacidad;
+  final bool flagEstimacionProduccion;
   final VerificacionRepository verificacionRepository;
   final RealizarVerificacionDto dto;
 
@@ -108,6 +110,7 @@ class _DescripcionActividadMineraVerificadaPaginaState
           extra: {
             'actividad': widget.actividad,
             'flagMedicionCapacidad': widget.flagMedicionCapacidad,
+            'flagEstimacionProduccion': widget.flagEstimacionProduccion,
             'dto': dtoActualizado,
           });
     }

--- a/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
@@ -18,6 +18,7 @@ class EvaluacionLaborPagina extends StatefulWidget {
     required this.actividad,
     required this.repository,
     required this.flagMedicionCapacidad,
+    required this.flagEstimacionProduccion,
     required this.verificacionRepository,
     required this.dto,
   });
@@ -30,6 +31,9 @@ class EvaluacionLaborPagina extends StatefulWidget {
 
   /// Indica si la visita requiere medición de capacidad.
   final bool flagMedicionCapacidad;
+
+  /// Indica si la visita requiere estimación de producción.
+  final bool flagEstimacionProduccion;
 
   /// Repositorio para almacenar la evaluación.
   final VerificacionRepository verificacionRepository;
@@ -117,6 +121,8 @@ class _EvaluacionLaborPaginaState extends State<EvaluacionLaborPagina> {
     context.push('/flujo-visita/firma', extra: {
       'actividad': widget.actividad,
       'flagMedicionCapacidad': widget.flagMedicionCapacidad,
+      'flagEstimacionProduccion': widget.flagEstimacionProduccion,
+      'dto': dtoActualizado,
     });
   }
 

--- a/lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import '../../../../core/auth/auth_provider.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../../perfil/datos/modelos/usuario.dart';
+import '../../dominio/entidades/realizar_verificacion_dto.dart';
 
 /// Página para visualizar la información del usuario antes de firmar.
 class FirmaPagina extends StatelessWidget {
@@ -13,6 +14,8 @@ class FirmaPagina extends StatelessWidget {
     required this.actividad,
     required this.usuario,
     required this.flagMedicionCapacidad,
+    required this.flagEstimacionProduccion,
+    required this.dto,
   });
 
   /// Actividad asociada a la firma.
@@ -23,6 +26,12 @@ class FirmaPagina extends StatelessWidget {
 
   /// Indica si la visita requiere medición de capacidad.
   final bool flagMedicionCapacidad;
+
+  /// Indica si la visita requiere estimación de producción.
+  final bool flagEstimacionProduccion;
+
+  /// Datos actuales de la verificación.
+  final RealizarVerificacionDto dto;
 
   @override
   Widget build(BuildContext context) {
@@ -79,16 +88,24 @@ class FirmaPagina extends StatelessWidget {
                           Row(
                             mainAxisAlignment: MainAxisAlignment.end,
                             children: [
-                              if (flagMedicionCapacidad)
+                              if (flagEstimacionProduccion ||
+                                  flagMedicionCapacidad)
                                 TextButton(
                                   onPressed: () {
                                     Navigator.of(context).pop();
                                     context.push(
-                                        '/flujo-visita/estimacion-produccion');
+                                      '/flujo-visita/estimacion-produccion',
+                                      extra: {
+                                        'flagMedicionCapacidad':
+                                            flagMedicionCapacidad,
+                                        'dto': dto,
+                                      },
+                                    );
                                   },
-                                  child:
-                                      const Text('Ir a estimación producción'),
-                                ),
+                                  child: const Text('Estimacion Produccion'),
+                                )
+                              else
+                                const Text('Enviar'),
                               TextButton(
                                 onPressed: () {
                                   Navigator.of(context).pop();

--- a/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
@@ -24,12 +24,14 @@ class RegistroFotograficoVerificacionPagina extends StatefulWidget {
     super.key,
     required this.actividad,
     required this.flagMedicionCapacidad,
+    required this.flagEstimacionProduccion,
     required this.verificacionRepository,
     required this.dto,
   });
 
   final Actividad actividad;
   final bool flagMedicionCapacidad;
+  final bool flagEstimacionProduccion;
   final VerificacionRepository verificacionRepository;
   final RealizarVerificacionDto dto;
 
@@ -156,6 +158,7 @@ class _RegistroFotograficoVerificacionPaginaState
     context.push('/flujo-visita/evaluacion-labor', extra: {
       'actividad': widget.actividad,
       'flagMedicionCapacidad': widget.flagMedicionCapacidad,
+      'flagEstimacionProduccion': widget.flagEstimacionProduccion,
       'dto': _dto,
     });
   }

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -58,11 +58,14 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final verificacionRepo = VerificacionRepositoryImpl(
             VerificacionLocalDataSource(ServicioBdLocal()),
           );
-          final idVisita = state.extra as int;
+          final extras = state.extra! as Map<String, dynamic>;
+          final idVisita = extras['idVisita'] as int;
+          final flagEstimacion = extras['flagEstimacionProduccion'] as bool;
           return ActividadMineraReinfoPagina(
             repository: repo,
             verificacionRepository: verificacionRepo,
             idVisita: idVisita,
+            flagEstimacionProduccion: flagEstimacion,
           );
         },
       ),
@@ -80,10 +83,12 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final extras = state.extra! as Map<String, dynamic>;
           final flag = extras['flagMedicionCapacidad'] as bool? ?? false;
           final idVisita = extras['idVisita'] as int;
+          final flagEstimacion = extras['flagEstimacionProduccion'] as bool;
           return ActividadMineraVerificadaPagina(
             repository: repo,
             verificacionRepository: verificacionRepo,
             flagMedicionCapacidad: flag,
+            flagEstimacionProduccion: flagEstimacion,
             idVisita: idVisita,
           );
         },
@@ -94,6 +99,7 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final extras = state.extra! as Map<String, dynamic>;
           final actividad = extras['actividad'] as Actividad;
           final flag = extras['flagMedicionCapacidad'] as bool;
+          final flagEstimacion = extras['flagEstimacionProduccion'] as bool;
           final dto = extras['dto'] as RealizarVerificacionDto;
           final verificacionRepo = VerificacionRepositoryImpl(
             VerificacionLocalDataSource(ServicioBdLocal()),
@@ -101,6 +107,7 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           return DescripcionActividadMineraVerificadaPagina(
             actividad: actividad,
             flagMedicionCapacidad: flag,
+            flagEstimacionProduccion: flagEstimacion,
             verificacionRepository: verificacionRepo,
             dto: dto,
           );
@@ -120,10 +127,12 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final extras = state.extra! as Map<String, dynamic>;
           final actividad = extras['actividad'] as Actividad?;
           final idVisita = extras['idVisita'] as int;
+          final flagEstimacion = extras['flagEstimacionProduccion'] as bool;
           return ActividadMineraIgafomPagina(
             repository: repo,
             verificacionRepository: verificacionRepo,
             idVisita: idVisita,
+            flagEstimacionProduccion: flagEstimacion,
             actividadReinfo: actividad,
           );
         },
@@ -134,6 +143,7 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final extras = state.extra! as Map<String, dynamic>;
           final actividad = extras['actividad'] as Actividad;
           final flag = extras['flagMedicionCapacidad'] as bool;
+          final flagEstimacion = extras['flagEstimacionProduccion'] as bool;
           final dto = extras['dto'] as RealizarVerificacionDto;
           final verificacionRepo = VerificacionRepositoryImpl(
             VerificacionLocalDataSource(ServicioBdLocal()),
@@ -141,6 +151,7 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           return RegistroFotograficoVerificacionPagina(
             actividad: actividad,
             flagMedicionCapacidad: flag,
+            flagEstimacionProduccion: flagEstimacion,
             verificacionRepository: verificacionRepo,
             dto: dto,
           );
@@ -157,6 +168,7 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final extras = state.extra! as Map<String, dynamic>;
           final actividad = extras['actividad'] as Actividad;
           final flag = extras['flagMedicionCapacidad'] as bool;
+          final flagEstimacion = extras['flagEstimacionProduccion'] as bool;
           final dto = extras['dto'] as RealizarVerificacionDto;
           final verificacionRepo = VerificacionRepositoryImpl(
             VerificacionLocalDataSource(ServicioBdLocal()),
@@ -165,6 +177,7 @@ GoRouter createRouter(AuthNotifier authNotifier) {
             actividad: actividad,
             repository: repo,
             flagMedicionCapacidad: flag,
+            flagEstimacionProduccion: flagEstimacion,
             verificacionRepository: verificacionRepo,
             dto: dto,
           );
@@ -200,10 +213,14 @@ GoRouter createRouter(AuthNotifier authNotifier) {
           final extras = state.extra! as Map<String, dynamic>;
           final actividad = extras['actividad'] as Actividad;
           final flag = extras['flagMedicionCapacidad'] as bool;
+          final flagEstimacion = extras['flagEstimacionProduccion'] as bool;
+          final dto = extras['dto'] as RealizarVerificacionDto;
           return FirmaPagina(
             actividad: actividad,
             usuario: auth.usuario!,
             flagMedicionCapacidad: flag,
+            flagEstimacionProduccion: flagEstimacion,
+            dto: dto,
           );
         },
       ),

--- a/test/features/actividad/actividad_minera_igafom_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_igafom_pagina_test.dart
@@ -61,6 +61,7 @@ void main() {
         repository: repo,
         verificacionRepository: _FakeVerificacionRepository(),
         idVisita: 0,
+        flagEstimacionProduccion: false,
       ),
     ));
     await tester.pumpAndSettle();
@@ -83,6 +84,7 @@ void main() {
         repository: repo,
         verificacionRepository: _FakeVerificacionRepository(),
         idVisita: 0,
+        flagEstimacionProduccion: false,
       ),
     ));
     await tester.pumpAndSettle();
@@ -124,6 +126,7 @@ void main() {
             repository: repo,
             verificacionRepository: _FakeVerificacionRepository(),
             idVisita: 0,
+            flagEstimacionProduccion: false,
           ),
         ),
         GoRoute(

--- a/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
@@ -92,6 +92,7 @@ void main() {
         repository: repo,
         verificacionRepository: verificacionRepo,
         idVisita: 0,
+        flagEstimacionProduccion: false,
       ),
     ));
     await tester.pumpAndSettle();
@@ -121,6 +122,7 @@ void main() {
         repository: repo,
         verificacionRepository: verificacionRepo,
         idVisita: 0,
+        flagEstimacionProduccion: false,
       ),
     ));
     await tester.pumpAndSettle();
@@ -150,6 +152,7 @@ void main() {
         repository: repo,
         verificacionRepository: verificacionRepo,
         idVisita: 0,
+        flagEstimacionProduccion: false,
       ),
     ));
     await tester.pumpAndSettle();
@@ -181,6 +184,7 @@ void main() {
         repository: repo,
         verificacionRepository: verificacionRepo,
         idVisita: 0,
+        flagEstimacionProduccion: false,
       ),
     ));
     await tester.pumpAndSettle();
@@ -220,6 +224,7 @@ void main() {
         repository: repo,
         verificacionRepository: verificacionRepo,
         idVisita: 0,
+        flagEstimacionProduccion: false,
       ),
     ));
     await tester.pumpAndSettle();
@@ -260,6 +265,7 @@ void main() {
             repository: repo,
             verificacionRepository: verificacionRepo,
             idVisita: 0,
+            flagEstimacionProduccion: false,
           ),
         ),
         GoRoute(
@@ -355,6 +361,7 @@ void main() {
         repository: repo,
         verificacionRepository: verificacionRepo,
         idVisita: 0,
+        flagEstimacionProduccion: false,
       ),
     ));
     await tester.pumpAndSettle();

--- a/test/features/actividad/actividad_minera_verificada_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_verificada_pagina_test.dart
@@ -55,6 +55,7 @@ void main() {
         repository: repo,
         verificacionRepository: _FakeVerificacionRepository(),
         flagMedicionCapacidad: false,
+        flagEstimacionProduccion: false,
         idVisita: 0,
       ),
     ));
@@ -78,6 +79,7 @@ void main() {
         repository: repo,
         verificacionRepository: _FakeVerificacionRepository(),
         flagMedicionCapacidad: false,
+        flagEstimacionProduccion: false,
         idVisita: 0,
       ),
     ));

--- a/test/features/actividad/descripcion_actividad_minera_verificada_pagina_test.dart
+++ b/test/features/actividad/descripcion_actividad_minera_verificada_pagina_test.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 
 import 'package:veta_dorada_vinculacion_mobile/features/actividad/dominio/entidades/actividad.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/actividad/dominio/enums/origen.dart';
-import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/completar_visita_comando.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/descripcion.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/descripcion_actividad_verificada.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/evaluacion.dart';
@@ -12,48 +11,8 @@ import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/ent
 import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/foto.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/proveedor_snapshot.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/realizar_verificacion_dto.dart';
-import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/entidades/registro_fotografico.dart';
-import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/repositorios/flow_repository.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/dominio/repositorios/verificacion_repository.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart';
-
-class _FakeFlowRepository implements FlowRepository {
-  DescripcionActividadVerificada? descripcion;
-
-  @override
-  Future<void> guardarDescripcionActividadVerificada(
-      DescripcionActividadVerificada descripcion) async {
-    this.descripcion = descripcion;
-  }
-
-  @override
-  Future<DescripcionActividadVerificada?>
-      obtenerDescripcionActividadVerificada() async => descripcion;
-
-  @override
-  Future<void> guardarEvaluacion(Evaluacion evaluacion) async {}
-
-  @override
-  Future<Evaluacion?> obtenerEvaluacion() async => null;
-
-  @override
-  Future<void> guardarEstimacion(Estimacion estimacion) async {}
-
-  @override
-  Future<Estimacion?> obtenerEstimacion() async => null;
-
-  @override
-  Future<void> agregarFotoVerificacion(RegistroFotografico foto) async {}
-
-  @override
-  Future<void> eliminarFotoVerificacion(int index) async {}
-
-  @override
-  Future<List<RegistroFotografico>> obtenerFotosVerificacion() async => [];
-
-  @override
-  Future<void> completarFlujo(CompletarVisitaComando comando) async {}
-}
 
 class _MockVerificacionRepository implements VerificacionRepository {
   RealizarVerificacionDto? savedDto;
@@ -111,7 +70,6 @@ void main() {
       idempotencyKey: '',
     );
 
-    final flowRepo = _FakeFlowRepository();
     final verificacionRepo = _MockVerificacionRepository();
 
     final router = GoRouter(routes: [
@@ -120,7 +78,7 @@ void main() {
         builder: (context, state) => DescripcionActividadMineraVerificadaPagina(
           actividad: actividad,
           flagMedicionCapacidad: false,
-          flowRepository: flowRepo,
+          flagEstimacionProduccion: false,
           verificacionRepository: verificacionRepo,
           dto: dto,
         ),

--- a/test/features/flujo_visita/flujo_actividad_minera_pagina_test.dart
+++ b/test/features/flujo_visita/flujo_actividad_minera_pagina_test.dart
@@ -65,6 +65,7 @@ void main() {
             repository: repo,
             verificacionRepository: verificacionRepo,
             idVisita: 1,
+            flagEstimacionProduccion: false,
           ),
         ),
         GoRoute(
@@ -75,6 +76,8 @@ void main() {
               repository: repo,
               verificacionRepository: verificacionRepo,
               idVisita: extras['idVisita'] as int,
+              flagEstimacionProduccion:
+                  extras['flagEstimacionProduccion'] as bool,
               actividadReinfo: extras['actividad'] as Actividad?,
             );
           },
@@ -86,7 +89,10 @@ void main() {
             return ActividadMineraVerificadaPagina(
               repository: repo,
               verificacionRepository: verificacionRepo,
-              flagMedicionCapacidad: extras['flagMedicionCapacidad'] as bool,
+              flagMedicionCapacidad:
+                  extras['flagMedicionCapacidad'] as bool,
+              flagEstimacionProduccion:
+                  extras['flagEstimacionProduccion'] as bool,
               idVisita: extras['idVisita'] as int,
             );
           },


### PR DESCRIPTION
## Summary
- add flow flag to estimation production and capacity buttons
- show Estimacion Produccion option or Enviar label in verification dialog
- propagate estimation flag through visit flow

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa0975e9c8331adae648c99f4f1c1