### PR TITLE
refactor: use ProtectedScaffold in flow pages

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../../actividad/datos/repositorios/actividad_repository_impl.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../../actividad/dominio/entidades/tipo_actividad.dart';
@@ -258,16 +260,31 @@ class _ActividadMineraIgafomPaginaState
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-          title: const Text(
-              'Actividad Minera Declarada por el Proveedor de Mineral en el IGAFOM')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Form(
         key: _formKey,
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
+              const SizedBox(
+                width: 378,
+                child: Text(
+                  'Actividad Minera Declarada por el Proveedor de Mineral en el IGAFOM',
+                  style: TextStyle(
+                    color: Color(0xFF1D1B20),
+                    fontSize: 22,
+                    fontFamily: 'Roboto',
+                    fontWeight: FontWeight.w400,
+                    height: 1.27,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
               DropdownButtonFormField<TipoActividad>(
                 decoration: const InputDecoration(
                   labelText: 'Tipo de actividad',

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../../actividad/datos/repositorios/actividad_repository_impl.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../../actividad/dominio/entidades/tipo_actividad.dart';
@@ -244,16 +246,31 @@ class _ActividadMineraReinfoPaginaState
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-          title: const Text(
-              'Actividad Minera Declarada por el Proveedor de Mineral en el Comprobante de Recepción de Datos para el REINFO')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Form(
         key: _formKey,
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
+              const SizedBox(
+                width: 378,
+                child: Text(
+                  'Actividad Minera Declarada por el Proveedor de Mineral en el Comprobante de Recepción de Datos para el REINFO',
+                  style: TextStyle(
+                    color: Color(0xFF1D1B20),
+                    fontSize: 22,
+                    fontFamily: 'Roboto',
+                    fontWeight: FontWeight.w400,
+                    height: 1.27,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
               DropdownButtonFormField<TipoActividad>(
                 decoration: const InputDecoration(
                   labelText: 'Tipo de actividad',

--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../../actividad/datos/repositorios/actividad_repository_impl.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../../actividad/dominio/entidades/tipo_actividad.dart';
@@ -269,14 +271,31 @@ class _ActividadMineraVerificadaPaginaState
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Actividad Minera Verificada')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Form(
         key: _formKey,
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
+              const SizedBox(
+                width: 378,
+                child: Text(
+                  'Actividad Minera Verificada',
+                  style: TextStyle(
+                    color: Color(0xFF1D1B20),
+                    fontSize: 22,
+                    fontFamily: 'Roboto',
+                    fontWeight: FontWeight.w400,
+                    height: 1.27,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
               Center(
                   child: Text('${(_avance * _totalPasos).round()} de '
                       '$_totalPasos')),

--- a/lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:veta_dorada_vinculacion_mobile/features/visitas/dominio/entidades/visita.dart';
 
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../datos/repositorios/general_repository.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../dominio/entidades/descripcion.dart';
@@ -209,8 +211,11 @@ class _DatosProveedorMineralPaginaState
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Datos de proveedor de mineral')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Form(
         key: _formKey,
         onChanged: () => setState(() {}),
@@ -219,6 +224,20 @@ class _DatosProveedorMineralPaginaState
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              const SizedBox(
+                width: 378,
+                child: Text(
+                  'Datos del proveedor de mineral',
+                  style: TextStyle(
+                    color: Color(0xFF1D1B20),
+                    fontSize: 22,
+                    fontFamily: 'Roboto',
+                    fontWeight: FontWeight.w400,
+                    height: 1.27,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
               Center(
                   child: Text('${(_avance * _totalPasos).round()} de '
                       '$_totalPasos')),

--- a/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../dominio/entidades/descripcion_actividad_verificada.dart';
 import '../../dominio/entidades/descripcion.dart';
@@ -118,8 +120,11 @@ class _DescripcionActividadMineraVerificadaPaginaState
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Descripción Actividad Verificada')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Form(
         key: _formKey,
         child: SingleChildScrollView(
@@ -127,6 +132,20 @@ class _DescripcionActividadMineraVerificadaPaginaState
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              const SizedBox(
+                width: 378,
+                child: Text(
+                  'Descripción Actividad Verificada',
+                  style: TextStyle(
+                    color: Color(0xFF1D1B20),
+                    fontSize: 22,
+                    fontFamily: 'Roboto',
+                    fontWeight: FontWeight.w400,
+                    height: 1.27,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
               Center(
                   child: Text('${(_avance * _totalPasos).round()} de '
                       '$_totalPasos')),

--- a/lib/features/flujo_visita/presentacion/paginas/estimacion_produccion_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/estimacion_produccion_pagina.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../dominio/entidades/estimacion.dart';
 import '../../dominio/entidades/realizar_verificacion_dto.dart';
 import '../../dominio/repositorios/verificacion_repository.dart';
@@ -99,13 +101,30 @@ class _EstimacionProduccionPaginaState
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Estimación de Producción')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Form(
         key: _formKey,
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
+            const SizedBox(
+              width: 378,
+              child: Text(
+                'Estimación de Producción',
+                style: TextStyle(
+                  color: Color(0xFF1D1B20),
+                  fontSize: 22,
+                  fontFamily: 'Roboto',
+                  fontWeight: FontWeight.w400,
+                  height: 1.27,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
             TextFormField(
               controller: _longitudController,
               keyboardType: TextInputType.number,

--- a/lib/features/flujo_visita/presentacion/paginas/estimacion_produccion_resultado_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/estimacion_produccion_resultado_pagina.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../dominio/entidades/estimacion.dart';
 
 /// Página que muestra el resultado de la estimación de producción.
@@ -14,33 +17,57 @@ class EstimacionProduccionResultadoPagina extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Resultado de Estimación')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              'Producción diaria estimada (Pd): '
-              '${estimacion.produccionDiariaEstimada.toStringAsFixed(2)}',
-              style: Theme.of(context).textTheme.titleMedium,
-              textAlign: TextAlign.center,
+            const SizedBox(
+              width: 378,
+              child: Text(
+                'Resultado de Estimación',
+                style: TextStyle(
+                  color: Color(0xFF1D1B20),
+                  fontSize: 22,
+                  fontFamily: 'Roboto',
+                  fontWeight: FontWeight.w400,
+                  height: 1.27,
+                ),
+              ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              'Producción mensual estimada (pme): '
-              '${estimacion.produccionMensualEstimada.toStringAsFixed(2)}',
-              style: Theme.of(context).textTheme.titleMedium,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Producción mensual: '
-              '${estimacion.produccionMensual.toStringAsFixed(2)}',
-              style: Theme.of(context).textTheme.titleMedium,
-              textAlign: TextAlign.center,
+            const SizedBox(height: 24),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    'Producción diaria estimada (Pd): '
+                    '${estimacion.produccionDiariaEstimada.toStringAsFixed(2)}',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Producción mensual estimada (pme): '
+                    '${estimacion.produccionMensualEstimada.toStringAsFixed(2)}',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Producción mensual: '
+                    '${estimacion.produccionMensual.toStringAsFixed(2)}',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../datos/repositorios/general_repository.dart';
 import '../../dominio/entidades/condicion_prospecto.dart';
@@ -128,8 +130,11 @@ class _EvaluacionLaborPaginaState extends State<EvaluacionLaborPagina> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Evaluación de la labor')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Form(
         key: _formKey,
         child: SingleChildScrollView(
@@ -137,6 +142,20 @@ class _EvaluacionLaborPaginaState extends State<EvaluacionLaborPagina> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              const SizedBox(
+                width: 378,
+                child: Text(
+                  'Evaluación de la labor',
+                  style: TextStyle(
+                    color: Color(0xFF1D1B20),
+                    fontSize: 22,
+                    fontFamily: 'Roboto',
+                    fontWeight: FontWeight.w400,
+                    height: 1.27,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
               DropdownButtonFormField<CondicionProspecto>(
                 decoration: const InputDecoration(
                   labelText: 'Condición del prospecto',

--- a/lib/features/flujo_visita/presentacion/paginas/firma_digital_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/firma_digital_pagina.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 
 /// Pantalla temporal para la funcionalidad de firma digital.
 class FirmaDigitalPagina extends StatelessWidget {
@@ -6,9 +10,32 @@ class FirmaDigitalPagina extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Center(
-        child: Text('Pantalla de firma digital (pendiente)'),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            SizedBox(
+              width: 378,
+              child: Text(
+                'Firma digital',
+                style: TextStyle(
+                  color: Color(0xFF1D1B20),
+                  fontSize: 22,
+                  fontFamily: 'Roboto',
+                  fontWeight: FontWeight.w400,
+                  height: 1.27,
+                ),
+              ),
+            ),
+            SizedBox(height: 16),
+            Text('Pantalla de firma digital (pendiente)'),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 import '../../../actividad/dominio/entidades/actividad.dart';
 import '../../../perfil/datos/modelos/usuario.dart';
 import '../../dominio/entidades/realizar_verificacion_dto.dart';
@@ -36,15 +37,32 @@ class FirmaPagina extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Se obtiene el usuario autenticado por si cambia durante la navegación.
-    final currentUser = AuthProvider.of(context).usuario ?? usuario;
+    final auth = AuthProvider.of(context);
+    final currentUser = auth.usuario ?? usuario;
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Firma')),
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            const SizedBox(
+              width: 378,
+              child: Text(
+                'Firma',
+                style: TextStyle(
+                  color: Color(0xFF1D1B20),
+                  fontSize: 22,
+                  fontFamily: 'Roboto',
+                  fontWeight: FontWeight.w400,
+                  height: 1.27,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
             Text('DNI: ${currentUser.id}'),
             const SizedBox(height: 8),
             Text('Nombre y apellidos: ${currentUser.nombre}'),

--- a/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart
@@ -14,6 +14,8 @@ import '../../dominio/entidades/realizar_verificacion_dto.dart';
 import '../../dominio/entidades/foto.dart';
 import '../../dominio/calcular_avance.dart';
 import '../../dominio/repositorios/verificacion_repository.dart';
+import '../../../../core/auth/auth_provider.dart';
+import '../../../../core/widgets/protected_scaffold.dart';
 
 /// Página para registrar fotografías durante la verificación.
 ///
@@ -191,12 +193,29 @@ class _RegistroFotograficoVerificacionPaginaState
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Registro Fotográfico')),
+    final auth = AuthProvider.of(context);
+    return ProtectedScaffold(
+      usuario: auth.usuario!,
+      token: auth.token!,
+      onNavigate: (ruta) => context.go(ruta),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
+            const SizedBox(
+              width: 378,
+              child: Text(
+                'Registro Fotográfico',
+                style: TextStyle(
+                  color: Color(0xFF1D1B20),
+                  fontSize: 22,
+                  fontFamily: 'Roboto',
+                  fontWeight: FontWeight.w400,
+                  height: 1.27,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
             Center(
                 child: Text('${(_avance * _totalPasos).round()} de '
                     '$_totalPasos')),
@@ -239,8 +258,8 @@ class _RegistroFotograficoVerificacionPaginaState
               ),
             )
           ],
+        ),
       ),
-      ),
-      );
+    );
   }
 }


### PR DESCRIPTION
## Summary
- replace Scaffold and app bars with ProtectedScaffold across flujo_visita pages
- display each page title within body using consistent styled text

## Testing
- `dart format lib/features/flujo_visita/presentacion/paginas/actividad_minera_igafom_pagina.dart lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart lib/features/flujo_visita/presentacion/paginas/datos_proveedor_mineral_pagina.dart lib/features/flujo_visita/presentacion/paginas/descripcion_actividad_minera_verificada_pagina.dart lib/features/flujo_visita/presentacion/paginas/estimacion_produccion_pagina.dart lib/features/flujo_visita/presentacion/paginas/estimacion_produccion_resultado_pagina.dart lib/features/flujo_visita/presentacion/paginas/evaluacion_labor_pagina.dart lib/features/flujo_visita/presentacion/paginas/firma_digital_pagina.dart lib/features/flujo_visita/presentacion/paginas/firma_pagina.dart lib/features/flujo_visita/presentacion/paginas/registro_fotografico_verificacion_pagina.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68aafa27915483319116ae9888bb6f85