### PR TITLE
feat: add bottom navigation actions widget

### DIFF
--- a/lib/core/widgets/bottom_nav_actions.dart
+++ b/lib/core/widgets/bottom_nav_actions.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// Acciones de navegación inferior con botones "Atrás" y "Siguiente".
+class BottomNavActions extends StatelessWidget {
+  const BottomNavActions({
+    super.key,
+    this.onBack,
+    required this.onNext,
+    this.nextText = 'Siguiente',
+    this.showBack,
+  });
+
+  /// Callback opcional que se ejecuta al presionar "Atrás".
+  final VoidCallback? onBack;
+
+  /// Callback requerido para la acción "Siguiente".
+  final VoidCallback onNext;
+
+  /// Texto del botón "Siguiente".
+  final String nextText;
+
+  /// Determina si se muestra el botón "Atrás". Si es `null`, se
+  /// evalúa `Navigator.of(context).canPop()`.
+  final bool? showBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final mostrarAtras = showBack ?? Navigator.of(context).canPop();
+
+    return SafeArea(
+      child: Row(
+        children: [
+          if (mostrarAtras)
+            OutlinedButton.icon(
+              onPressed: onBack ?? () => Navigator.of(context).maybePop(),
+              icon: const Icon(Icons.arrow_back),
+              label: const Text('Atrás'),
+            ),
+          const Spacer(),
+          ElevatedButton(
+            onPressed: onNext,
+            child: Text(nextText),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add bottom navigation actions widget with next/back callbacks

## Testing
- `dart format lib/core/widgets/bottom_nav_actions.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab45d724348331adb4948ccd0dc2b4