### PR TITLE
Guardar verificación al abrir visita

### DIFF
--- a/lib/features/visitas/presentacion/componentes/visita_card.dart
+++ b/lib/features/visitas/presentacion/componentes/visita_card.dart
@@ -3,13 +3,23 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../dominio/entidades/visita.dart';
+import '../../../../core/auth/auth_provider.dart';
+import '../../../flujo_visita/dominio/entidades/realizar_verificacion_dto.dart';
+import '../../../flujo_visita/dominio/repositorios/verificacion_repository.dart';
 
 /// Tarjeta que muestra la información principal de una [Visita].
 class VisitaCard extends StatelessWidget {
-  const VisitaCard({super.key, required this.visita});
+  const VisitaCard({
+    super.key,
+    required this.visita,
+    required this.verificacionRepository,
+  });
 
   /// Visita que se va a mostrar.
   final Visita visita;
+
+  /// Repositorio para persistir la verificación.
+  final VerificacionRepository verificacionRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -21,8 +31,18 @@ class VisitaCard extends StatelessWidget {
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       elevation: 0,
       child: InkWell(
-        onTap: () =>
-            context.push('/flujo-visita/datos-proveedor', extra: visita),
+        onTap: () async {
+          final auth = AuthProvider.of(context);
+          final dto = RealizarVerificacionDto(
+            idVerificacion: DateTime.now().millisecondsSinceEpoch,
+            idVisita: visita.id,
+            idUsuario: auth.usuario!.id,
+            idempotencyKey:
+                '${DateTime.now().microsecondsSinceEpoch}-${visita.id}',
+          );
+          await verificacionRepository.guardarVerificacion(dto);
+          context.push('/flujo-visita/datos-proveedor', extra: visita);
+        },
         child: Padding(
           padding: const EdgeInsets.all(10),
           child: Column(

--- a/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
+++ b/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
@@ -12,6 +12,7 @@ import '../componentes/pestana_personalizada.dart';
 import '../componentes/visita_card.dart';
 import '../../../flujo_visita/datos/fuentes_datos/verificacion_local_data_source.dart';
 import '../../../flujo_visita/datos/repositorios/verificacion_repository_impl.dart';
+import '../../../flujo_visita/dominio/repositorios/verificacion_repository.dart';
 
 /// Página que muestra las visitas organizadas en pestañas.
 class VisitasTabsPage extends StatefulWidget {
@@ -23,6 +24,7 @@ class VisitasTabsPage extends StatefulWidget {
 
 class _VisitasTabsPageState extends State<VisitasTabsPage> {
   late VisitasBloc _bloc;
+  late VerificacionRepository _verificacionRepository;
   bool _inicializado = false;
 
   @override
@@ -35,8 +37,9 @@ class _VisitasTabsPageState extends State<VisitasTabsPage> {
     final repo = VisitsRepositoryImpl(remoto, local);
     final verificacionLocal =
         VerificacionLocalDataSource(ServicioBdLocal());
-    final verificacionRepo = VerificacionRepositoryImpl(verificacionLocal);
-    _bloc = VisitasBloc(repo, verificacionRepo)
+    _verificacionRepository =
+        VerificacionRepositoryImpl(verificacionLocal);
+    _bloc = VisitasBloc(repo, _verificacionRepository)
       ..add(CargarVisitas(auth.usuario!.id));
     _bloc.stream.listen((state) {
       if (state is VisitasCargadas && state.advertencia != null) {
@@ -113,7 +116,10 @@ class _VisitasTabsPageState extends State<VisitasTabsPage> {
       itemCount: visitas.length,
       itemBuilder: (context, index) {
         final visita = visitas[index];
-        return VisitaCard(visita: visita);
+        return VisitaCard(
+          visita: visita,
+          verificacionRepository: _verificacionRepository,
+        );
       },
     );
   }


### PR DESCRIPTION
## Summary
- Inyecta VerificacionRepository en VisitaCard y persiste una verificación mínima al pulsar
- Propaga VerificacionRepository desde VisitasTabsPage hasta la tarjeta de visita

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab536dc9108331b943e6f97df49033