### PR TITLE
Refresh auth token on startup when missing or expired

### DIFF
--- a/test/features/autenticacion/init_auth_refresh_test.dart
+++ b/test/features/autenticacion/init_auth_refresh_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/main.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/auth/auth_notifier.dart';
+import 'package:veta_dorada_vinculacion_mobile/core/red/respuesta_base.dart';
+import 'package:veta_dorada_vinculacion_mobile/features/perfil/datos/modelos/usuario.dart';
+
+class FakeAuthRemoteDataSource {
+  FakeAuthRemoteDataSource(this.storage);
+  final FlutterSecureStorage storage;
+
+  Future<void> loadFromStorage() async {}
+
+  Future<String> refreshToken() async {
+    final refresh = await storage.read(key: 'refreshToken');
+    if (refresh == null) {
+      throw Exception('no refresh token');
+    }
+    const newToken = 'new_access_token';
+    await storage.write(key: 'accessToken', value: newToken);
+    await storage.write(
+      key: 'accessTokenExpiry',
+      value: DateTime.now().add(const Duration(hours: 1)).toIso8601String(),
+    );
+    return newToken;
+  }
+}
+
+class FakePerfilRemoteDataSource {
+  Future<RespuestaBase<Usuario>> obtenerPerfil() async {
+    final usuario =
+        Usuario(id: '1', nombre: 'Test', correo: 'test@example.com');
+    return RespuestaBase.respuestaCorrecta(usuario);
+  }
+}
+
+void main() {
+  test('initAuth refreshes token and loads profile when only refresh token present', () async {
+    FlutterSecureStorage.setMockInitialValues({
+      'refreshToken': 'refresh_token',
+    });
+    final notifier = AuthNotifier();
+    await initAuth(
+      notifier,
+      authDataSourceBuilder: (storage) => FakeAuthRemoteDataSource(storage),
+      perfilDataSourceBuilder: (_) => FakePerfilRemoteDataSource(),
+    );
+
+    expect(notifier.token, 'new_access_token');
+    expect(notifier.usuario, isNotNull);
+    expect(notifier.usuario!.nombre, 'Test');
+  });
+}


### PR DESCRIPTION
## Summary
- Refresh access token when none or expired during initialization
- Use refreshed token to retrieve user profile and update auth state
- Add test covering refresh flow with only a refresh token in storage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab848887848331877e856908b6ad84