### PR TITLE
Adjust BottomNavActions layout

### DIFF
--- a/lib/core/widgets/bottom_nav_actions.dart
+++ b/lib/core/widgets/bottom_nav_actions.dart
@@ -36,11 +36,19 @@ class BottomNavActions extends StatelessWidget {
               icon: const Icon(Icons.arrow_back),
               label: const Text('Atrás'),
             ),
-          const Spacer(),
-          ElevatedButton(
-            onPressed: onNext,
-            child: Text(nextText),
-          ),
+          if (mostrarAtras) const Spacer(),
+          if (mostrarAtras)
+            ElevatedButton(
+              onPressed: onNext,
+              child: Text(nextText),
+            )
+          else
+            Expanded(
+              child: ElevatedButton(
+                onPressed: onNext,
+                child: Text(nextText),
+              ),
+            ),
         ],
       ),
     );

--- a/test/features/core/bottom_nav_actions_test.dart
+++ b/test/features/core/bottom_nav_actions_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:veta_dorada_vinculacion_mobile/core/widgets/bottom_nav_actions.dart';
+
+void main() {
+  testWidgets(
+      'Botón "Siguiente" ocupa todo el ancho cuando no se muestra "Atrás"',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: BottomNavActions(
+            onNext: _dummy,
+            showBack: false,
+          ),
+        ),
+      ),
+    );
+
+    final screenWidth =
+        tester.binding.window.physicalSize.width /
+            tester.binding.window.devicePixelRatio;
+    final buttonWidth =
+        tester.getSize(find.byType(ElevatedButton)).width;
+
+    expect(buttonWidth, moreOrLessEquals(screenWidth, epsilon: 1));
+  });
+
+  testWidgets(
+      'Se muestran ambos botones cuando mostrarAtras es verdadero',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: BottomNavActions(
+            onNext: _dummy,
+            showBack: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(OutlinedButton), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+
+    final screenWidth =
+        tester.binding.window.physicalSize.width /
+            tester.binding.window.devicePixelRatio;
+    final buttonWidth =
+        tester.getSize(find.byType(ElevatedButton)).width;
+
+    expect(buttonWidth, lessThan(screenWidth));
+  });
+}
+
+void _dummy() {}


### PR DESCRIPTION
## Summary
- Expand the "Siguiente" button to full width when the back button is hidden
- Add widget tests verifying layout with and without the back button

## Testing
- `flutter test test/features/core/bottom_nav_actions_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab888069f88331a07d50ad7f9e9e41