### PR TITLE
Sincroniza visitas al regresar del flujo

### DIFF
--- a/lib/features/visitas/presentacion/bloc/visitas_bloc.dart
+++ b/lib/features/visitas/presentacion/bloc/visitas_bloc.dart
@@ -7,8 +7,8 @@ import '../../dominio/entidades/visita.dart';
 import '../../dominio/repositorios/visits_repository.dart';
 import '../../../flujo_visita/dominio/repositorios/verificacion_repository.dart';
 
-part 'visitas_event.dart';
-part 'visitas_state.dart';
+import 'visitas_event.dart';
+import 'visitas_state.dart';
 
 class VisitasBloc extends Bloc<VisitasEvent, VisitasState> {
   VisitasBloc(this._repository, this._verificacionRepository)

--- a/lib/features/visitas/presentacion/bloc/visitas_event.dart
+++ b/lib/features/visitas/presentacion/bloc/visitas_event.dart
@@ -1,5 +1,3 @@
-part of 'visitas_bloc.dart';
-
 abstract class VisitasEvent {}
 
 class CargarVisitas extends VisitasEvent {

--- a/lib/features/visitas/presentacion/bloc/visitas_state.dart
+++ b/lib/features/visitas/presentacion/bloc/visitas_state.dart
@@ -1,4 +1,4 @@
-part of 'visitas_bloc.dart';
+import '../../dominio/entidades/visita.dart';
 
 abstract class VisitasState {}
 

--- a/lib/features/visitas/presentacion/componentes/visita_card.dart
+++ b/lib/features/visitas/presentacion/componentes/visita_card.dart
@@ -6,6 +6,8 @@ import '../../dominio/entidades/visita.dart';
 import '../../../../core/auth/auth_provider.dart';
 import '../../../flujo_visita/dominio/entidades/realizar_verificacion_dto.dart';
 import '../../../flujo_visita/dominio/repositorios/verificacion_repository.dart';
+import '../bloc/visitas_bloc.dart';
+import '../bloc/visitas_event.dart';
 
 /// Tarjeta que muestra la información principal de una [Visita].
 class VisitaCard extends StatelessWidget {
@@ -13,6 +15,7 @@ class VisitaCard extends StatelessWidget {
     super.key,
     required this.visita,
     required this.verificacionRepository,
+    this.visitasBloc,
   });
 
   /// Visita que se va a mostrar.
@@ -20,6 +23,9 @@ class VisitaCard extends StatelessWidget {
 
   /// Repositorio para persistir la verificación.
   final VerificacionRepository verificacionRepository;
+
+  /// Bloc para gestionar las visitas.
+  final VisitasBloc? visitasBloc;
 
   @override
   Widget build(BuildContext context) {
@@ -41,7 +47,8 @@ class VisitaCard extends StatelessWidget {
                 '${DateTime.now().microsecondsSinceEpoch}-${visita.id}',
           );
           await verificacionRepository.guardarVerificacion(dto);
-          context.push('/flujo-visita/datos-proveedor', extra: visita);
+          await context.push('/flujo-visita/datos-proveedor', extra: visita);
+          visitasBloc?.add(SincronizarVisitas(auth.usuario!.id));
         },
         child: Padding(
           padding: const EdgeInsets.all(10),

--- a/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
+++ b/lib/features/visitas/presentacion/paginas/visitas_tabs_page.dart
@@ -8,6 +8,8 @@ import '../../datos/fuentes_datos/visits_remote_data_source.dart';
 import '../../datos/repositorios/visits_repository_impl.dart';
 import '../../dominio/entidades/visita.dart';
 import '../bloc/visitas_bloc.dart';
+import '../bloc/visitas_event.dart';
+import '../bloc/visitas_state.dart';
 import '../componentes/pestana_personalizada.dart';
 import '../componentes/visita_card.dart';
 import '../../../flujo_visita/datos/fuentes_datos/verificacion_local_data_source.dart';
@@ -119,6 +121,7 @@ class _VisitasTabsPageState extends State<VisitasTabsPage> {
         return VisitaCard(
           visita: visita,
           verificacionRepository: _verificacionRepository,
+          visitasBloc: _bloc,
         );
       },
     );


### PR DESCRIPTION
## Summary
- Refactoriza `VisitasBloc` para exponer eventos y estados mediante imports
- Espera a que finalice el flujo de verificación y sincroniza visitas al regresar
- Propaga el bloc de visitas a cada `VisitaCard` desde la página de pestañas

## Testing
- `flutter test` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abbe34a1308331afed44e734c4b975