### PR TITLE
Reload visits after completing verification

### DIFF
--- a/lib/features/visitas/presentacion/componentes/visita_card.dart
+++ b/lib/features/visitas/presentacion/componentes/visita_card.dart
@@ -39,21 +39,19 @@ class VisitaCard extends StatelessWidget {
       child: InkWell(
         onTap: () async {
           final auth = AuthProvider.of(context);
-          if(await verificacionRepository.obtenerVerificacion(visita.id)==null) {
+          if (await verificacionRepository.obtenerVerificacion(visita.id) ==
+              null) {
             final dto = RealizarVerificacionDto(
-              idVerificacion: DateTime
-                  .now()
-                  .millisecondsSinceEpoch,
+              idVerificacion: DateTime.now().millisecondsSinceEpoch,
               idVisita: visita.id,
               idUsuario: auth.usuario!.id,
               idempotencyKey:
-              '${DateTime
-                  .now()
-                  .microsecondsSinceEpoch}-${visita.id}',
+                  '${DateTime.now().microsecondsSinceEpoch}-${visita.id}',
             );
             await verificacionRepository.guardarVerificacion(dto);
           }
-          context.push('/flujo-visita/datos-proveedor', extra: visita);
+          await context.push('/flujo-visita/datos-proveedor', extra: visita);
+          visitasBloc?.add(SincronizarVisitas(auth.usuario!.id));
         },
         child: Padding(
           padding: const EdgeInsets.all(10),


### PR DESCRIPTION
## Summary
- reload visitas list after returning from verification to remove completed card

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abc3f9e4fc8331a6865409cc45d3e7