### PR TITLE
feat: support activity subtypes

### DIFF
--- a/lib/core/servicios/servicio_bd_local.dart
+++ b/lib/core/servicios/servicio_bd_local.dart
@@ -21,13 +21,14 @@ class ServicioBdLocal {
   static const String nombreTablaInicioProcesoFormalizacion =
       'inicio_proceso_formalizacion';
   static const String nombreTablaTipoActividad = 'tipo_actividad';
+  static const String nombreTablaSubTipoActividad = 'sub_tipo_actividad';
   static const String nombreTablaCondicionProspecto =
       'condicion_prospecto';
   static const String nombreTablaRealizarVerificacion =
       'realizar_verificacion';
 
   static const _nombreBd = 'vinculacion.db';
-  static const _versionBd = 4;
+  static const _versionBd = 5;
 
   Database? _db;
 
@@ -63,6 +64,13 @@ class ServicioBdLocal {
           CREATE TABLE $nombreTablaTipoActividad(
             id INTEGER PRIMARY KEY,
             nombre TEXT
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE $nombreTablaSubTipoActividad(
+            id INTEGER PRIMARY KEY,
+            nombre TEXT,
+            tipoActividadId INTEGER
           );
         ''');
         await db.execute('''
@@ -104,6 +112,15 @@ class ServicioBdLocal {
             await db.execute(
                 'ALTER TABLE $nombreTablaTipoActividad RENAME COLUMN codigo TO id;');
           } catch (_) {}
+        }
+        if (oldVersion < 5) {
+          await db.execute('''
+            CREATE TABLE IF NOT EXISTS $nombreTablaSubTipoActividad(
+              id INTEGER PRIMARY KEY,
+              nombre TEXT,
+              tipoActividadId INTEGER
+            );
+          ''');
         }
       },
     );

--- a/lib/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart
+++ b/lib/features/actividad/datos/fuentes_datos/tipo_actividad_remote_data_source.dart
@@ -25,9 +25,18 @@ class TipoActividadRemoteDataSource {
           data['CodigoRespuesta'] as int? ?? RespuestaBase.RESPUESTA_ERROR;
       if (codigo == RespuestaBase.RESPUESTA_CORRECTA &&
           data['Respuesta'] is List) {
-        final tipos = (data['Respuesta'] as List<dynamic>)
-            .map((e) => TipoActividad.fromJson(e as Map<String, dynamic>))
-            .toList();
+        final tipos = (data['Respuesta'] as List<dynamic>).map((e) {
+          final json = e as Map<String, dynamic>;
+          final subTipos = (json['SubTipos'] as List<dynamic>? ?? [])
+              .map(
+                  (st) => SubTipoActividad.fromJson(st as Map<String, dynamic>))
+              .toList();
+          return TipoActividad(
+            id: json['Id'] as int,
+            nombre: json['Nombre'] as String,
+            subTipos: subTipos,
+          );
+        }).toList();
         return RespuestaBase(codigoRespuesta: codigo, respuesta: tipos);
       } else {
         return RespuestaBase(

--- a/lib/features/actividad/datos/repositorios/actividad_repository_impl.dart
+++ b/lib/features/actividad/datos/repositorios/actividad_repository_impl.dart
@@ -12,19 +12,18 @@ class ActividadRepositoryImpl {
   final TipoActividadRemoteDataSource _remoteDataSource;
   final TipoActividadLocalDataSource _localDataSource;
 
-  /// Sincroniza los tipos de actividad descargándolos desde la API y
-  /// almacenándolos localmente.
+  /// Sincroniza los tipos de actividad y sus subtipos descargándolos desde la
+  /// API y almacenándolos localmente.
   Future<void> sincronizarTiposActividad() async {
     final respuesta = await _remoteDataSource.obtenerTiposActividad();
     if (respuesta.codigoRespuesta == RespuestaBase.RESPUESTA_CORRECTA &&
         respuesta.respuesta != null) {
       await _localDataSource.reemplazarTiposActividad(respuesta.respuesta!);
-    } else {
-      await _localDataSource.reemplazarTiposActividad(const []);
     }
   }
 
-  /// Obtiene los tipos de actividad, intentando primero desde la API.
+  /// Obtiene los tipos de actividad y sus subtipos, intentando primero desde la
+  /// API.
   ///
   /// Si la solicitud remota falla, devuelve los datos locales y un mensaje
   /// de advertencia con la causa del fallo.

--- a/lib/features/actividad/dominio/entidades/tipo_actividad.dart
+++ b/lib/features/actividad/dominio/entidades/tipo_actividad.dart
@@ -6,19 +6,30 @@ class TipoActividad {
   /// Nombre legible del tipo.
   final String nombre;
 
+  /// Colección de sub tipos asociados a este tipo de actividad.
+  final List<SubTipoActividad> subTipos;
+
   /// Crea una instancia de [TipoActividad].
-  const TipoActividad({required this.id, required this.nombre});
+  const TipoActividad({
+    required this.id,
+    required this.nombre,
+    this.subTipos = const [],
+  });
 
   /// Construye un [TipoActividad] a partir de un mapa JSON.
   factory TipoActividad.fromJson(Map<String, dynamic> json) => TipoActividad(
         id: json['Id'] as int,
         nombre: json['Nombre'] as String,
+        subTipos: (json['SubTipos'] as List<dynamic>? ?? [])
+            .map((e) => SubTipoActividad.fromJson(e as Map<String, dynamic>))
+            .toList(),
       );
 
   /// Convierte el [TipoActividad] en un mapa JSON.
   Map<String, dynamic> toJson() => {
         'Id': id,
         'Nombre': nombre,
+        'SubTipos': subTipos.map((e) => e.toJson()).toList(),
       };
 }
 

--- a/test/features/actividad/actividad_repository_impl_test.dart
+++ b/test/features/actividad/actividad_repository_impl_test.dart
@@ -47,7 +47,7 @@ void main() {
       expect(local.almacenados.first.nombre, 'Exploración');
     });
 
-    test('sincronizarTiposActividad limpia datos cuando hay error', () async {
+    test('sincronizarTiposActividad mantiene datos cuando hay error', () async {
       final remoto = _FakeRemote(RespuestaBase(
         codigoRespuesta: RespuestaBase.RESPUESTA_ERROR,
         mensajeError: 'fallo',
@@ -58,7 +58,8 @@ void main() {
 
       await repo.sincronizarTiposActividad();
 
-      expect(local.almacenados, isEmpty);
+      expect(local.almacenados, isNotEmpty);
+      expect(local.almacenados.first.nombre, 'A');
     });
 
     test('obtenerTiposActividad retorna datos remotos y sincroniza locales', () async {

--- a/test/features/actividad/tipo_actividad_remote_data_source_test.dart
+++ b/test/features/actividad/tipo_actividad_remote_data_source_test.dart
@@ -16,8 +16,14 @@ void main() {
         final body = jsonEncode({
           'CodigoRespuesta': RespuestaBase.RESPUESTA_CORRECTA,
           'Respuesta': [
-            {'Id': 1, 'Nombre': 'Exploración'},
-            {'Id': 2, 'Nombre': 'Beneficio'},
+            {
+              'Id': 1,
+              'Nombre': 'Exploración',
+              'SubTipos': [
+                {'Id': 10, 'Nombre': 'Aluvial'},
+              ]
+            },
+            {'Id': 2, 'Nombre': 'Beneficio', 'SubTipos': []},
           ],
         });
         return http.Response(body, 200);
@@ -31,6 +37,7 @@ void main() {
       expect(respuesta.respuesta, isA<List<TipoActividad>>());
       expect(respuesta.respuesta!.length, 2);
       expect(respuesta.respuesta!.first.nombre, 'Exploración');
+      expect(respuesta.respuesta!.first.subTipos.first.nombre, 'Aluvial');
     });
 
     test('devuelve error cuando el servidor responde con código no 200', () async {


### PR DESCRIPTION
## Summary
- track sub activity types in domain models with JSON serialization
- map sub activity types from API and persist them locally with new SQLite table
- keep local sub types when sync fails and extend tests

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68abd4fcb5808331923222b416db1932