### PR TITLE
feat: use provided subtypes and save selected id

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_verificada_pagina.dart
@@ -58,15 +58,9 @@ class _ActividadMineraVerificadaPaginaState
 
   List<TipoActividad> _tipos = [];
   TipoActividad? _tipoSeleccionado;
-  String? _subTipoSeleccionado;
-  List<String> _subTiposDisponibles = [];
+  SubTipoActividad? _subTipoSeleccionado;
+  List<SubTipoActividad> _subTiposDisponibles = [];
   String _labelSubTipo = 'Sub Tipo';
-
-  final Map<int, List<String>> _mapaSubTipos = {
-    // Opciones de ejemplo para los sub tipos dependiendo del tipo.
-    1: ['Aluvial', 'Filoniano'],
-    2: ['Gravimétrico', 'Lixiviación'],
-  };
 
   final TextEditingController _sistemaController = TextEditingController();
   final TextEditingController _zonaController = TextEditingController();
@@ -124,19 +118,16 @@ class _ActividadMineraVerificadaPaginaState
       for (final tipo in _tipos) {
         if (tipo.id == actividad.idTipoActividad) {
           _tipoSeleccionado = tipo;
-          final desc = tipo.nombre.toLowerCase();
-          if (desc.contains('beneficio')) {
-            _labelSubTipo = 'Tipo de Beneficio';
-          } else if (desc.contains('explot')) {
-            _labelSubTipo = 'Tipo de Explotación';
-          } else {
-            _labelSubTipo = 'Sub Tipo';
-          }
-          _subTiposDisponibles = _mapaSubTipos[tipo.id] ?? [];
-          if (actividad.idSubTipoActividad > 0 &&
-              actividad.idSubTipoActividad <= _subTiposDisponibles.length) {
-            _subTipoSeleccionado =
-                _subTiposDisponibles[actividad.idSubTipoActividad - 1];
+          _labelSubTipo = 'Tipo de ${tipo.nombre}';
+          _subTiposDisponibles = tipo.subTipos;
+          if (actividad.idSubTipoActividad > 0) {
+            try {
+              _subTipoSeleccionado = tipo.subTipos.firstWhere(
+                (st) => st.id == actividad.idSubTipoActividad,
+              );
+            } catch (_) {
+              _subTipoSeleccionado = null;
+            }
           }
           break;
         }
@@ -159,16 +150,9 @@ class _ActividadMineraVerificadaPaginaState
     setState(() {
       _tipoSeleccionado = tipo;
       _subTipoSeleccionado = null;
-      _subTiposDisponibles = _mapaSubTipos[tipo?.id] ?? [];
+      _subTiposDisponibles = tipo?.subTipos ?? [];
       if (tipo != null) {
-        final desc = tipo.nombre.toLowerCase();
-        if (desc.contains('beneficio')) {
-          _labelSubTipo = 'Tipo de Beneficio';
-        } else if (desc.contains('explot')) {
-          _labelSubTipo = 'Tipo de Explotación';
-        } else {
-          _labelSubTipo = 'Sub Tipo';
-        }
+        _labelSubTipo = 'Tipo de ${tipo.nombre}';
       } else {
         _labelSubTipo = 'Sub Tipo';
       }
@@ -185,8 +169,7 @@ class _ActividadMineraVerificadaPaginaState
       id: '',
       origen: Origen.verificada,
       idTipoActividad: _tipoSeleccionado!.id,
-      idSubTipoActividad:
-          _subTiposDisponibles.indexOf(_subTipoSeleccionado!) + 1,
+      idSubTipoActividad: _subTipoSeleccionado!.id,
       sistemaUTM: int.tryParse(_sistemaController.text) ?? 0,
       utmEste: double.tryParse(_comp01EsteController.text) ?? 0,
       utmNorte: double.tryParse(_comp01NorteController.text) ?? 0,
@@ -301,11 +284,14 @@ class _ActividadMineraVerificadaPaginaState
               ),
               const SizedBox(height: 16),
               if (_subTiposDisponibles.isNotEmpty)
-                DropdownButtonFormField<String>(
+                DropdownButtonFormField<SubTipoActividad>(
                   decoration: InputDecoration(labelText: _labelSubTipo),
                   value: _subTipoSeleccionado,
                   items: _subTiposDisponibles
-                      .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                      .map((e) => DropdownMenuItem(
+                            value: e,
+                            child: Text(e.nombre),
+                          ))
                       .toList(),
                   onChanged: (value) =>
                       setState(() => _subTipoSeleccionado = value),


### PR DESCRIPTION
## Summary
- load sub types directly from selected `TipoActividad`
- label sub type dropdown using selected type name
- persist sub type id when saving the activity

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd853fc948331b17149defc112994