### PR TITLE
test: cover subtype persistence in activity sync

### DIFF
--- a/test/features/actividad/actividad_repository_impl_test.dart
+++ b/test/features/actividad/actividad_repository_impl_test.dart
@@ -36,7 +36,13 @@ void main() {
     test('sincronizarTiposActividad guarda los datos obtenidos', () async {
       final remoto = _FakeRemote(RespuestaBase(
         codigoRespuesta: RespuestaBase.RESPUESTA_CORRECTA,
-        respuesta: [TipoActividad(id: 1, nombre: 'Exploración')],
+        respuesta: [
+          TipoActividad(
+            id: 1,
+            nombre: 'Exploración',
+            subTipos: const [SubTipoActividad(id: 10, nombre: 'Sub1')],
+          )
+        ],
       ));
       final local = _FakeLocal();
       final repo = ActividadRepositoryImpl(remoto, local);
@@ -45,6 +51,7 @@ void main() {
 
       expect(local.almacenados.length, 1);
       expect(local.almacenados.first.nombre, 'Exploración');
+      expect(local.almacenados.first.subTipos.first.nombre, 'Sub1');
     });
 
     test('sincronizarTiposActividad mantiene datos cuando hay error', () async {
@@ -53,19 +60,32 @@ void main() {
         mensajeError: 'fallo',
       ));
       final local = _FakeLocal();
-      local.almacenados = [TipoActividad(id: 1, nombre: 'A')];
+      local.almacenados = [
+        TipoActividad(
+          id: 1,
+          nombre: 'A',
+          subTipos: const [SubTipoActividad(id: 11, nombre: 'A1')],
+        )
+      ];
       final repo = ActividadRepositoryImpl(remoto, local);
 
       await repo.sincronizarTiposActividad();
 
       expect(local.almacenados, isNotEmpty);
       expect(local.almacenados.first.nombre, 'A');
+      expect(local.almacenados.first.subTipos.first.nombre, 'A1');
     });
 
     test('obtenerTiposActividad retorna datos remotos y sincroniza locales', () async {
       final remoto = _FakeRemote(RespuestaBase(
         codigoRespuesta: RespuestaBase.RESPUESTA_CORRECTA,
-        respuesta: [TipoActividad(id: 1, nombre: 'Exploración')],
+        respuesta: [
+          TipoActividad(
+            id: 1,
+            nombre: 'Exploración',
+            subTipos: const [SubTipoActividad(id: 10, nombre: 'Sub1')],
+          )
+        ],
       ));
       final local = _FakeLocal();
       final repo = ActividadRepositoryImpl(remoto, local);
@@ -75,6 +95,7 @@ void main() {
       expect(result.advertencia, isNull);
       expect(result.tipos.length, 1);
       expect(local.almacenados.length, 1);
+      expect(local.almacenados.first.subTipos.first.nombre, 'Sub1');
     });
 
     test('obtenerTiposActividad retorna locales cuando remoto falla', () async {
@@ -83,13 +104,20 @@ void main() {
         mensajeError: 'error remoto',
       ));
       final local = _FakeLocal();
-      local.almacenados = [TipoActividad(id: 2, nombre: 'Beneficio')];
+      local.almacenados = [
+        TipoActividad(
+          id: 2,
+          nombre: 'Beneficio',
+          subTipos: const [SubTipoActividad(id: 20, nombre: 'SubB')],
+        )
+      ];
       final repo = ActividadRepositoryImpl(remoto, local);
 
       final result = await repo.obtenerTiposActividad();
 
       expect(result.advertencia, 'error remoto');
       expect(result.tipos.first.nombre, 'Beneficio');
+      expect(result.tipos.first.subTipos.first.nombre, 'SubB');
     });
   });
 }


### PR DESCRIPTION
## Summary
- verify `ActividadRepositoryImpl` persists subtypes when synchronizing
- ensure offline retrieval returns stored subtypes

## Testing
- `flutter test test/features/actividad/actividad_repository_impl_test.dart` *(fails: command not found: flutter)*
- `git clone https://github.com/flutter/flutter.git -b stable --depth 1 /flutter` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abde3281808331a68c42b7145087a0