### PR TITLE
feat: swap UTM field for dropdown

### DIFF
--- a/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
+++ b/lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart
@@ -57,7 +57,7 @@ class _ActividadMineraReinfoPaginaState
   static const int _totalPasos = totalPasosVerificacion;
   double _avance = 0;
 
-  final TextEditingController _sistemaController = TextEditingController();
+  String _sistemaSeleccionado = 'WGS84';
   final TextEditingController _zonaController = TextEditingController();
   final TextEditingController _comp01EsteController = TextEditingController();
   final TextEditingController _comp01NorteController = TextEditingController();
@@ -77,7 +77,6 @@ class _ActividadMineraReinfoPaginaState
 
   @override
   void dispose() {
-    _sistemaController.dispose();
     _zonaController.dispose();
     _comp01EsteController.dispose();
     _comp01NorteController.dispose();
@@ -112,7 +111,9 @@ class _ActividadMineraReinfoPaginaState
           break;
         }
       }
-      _sistemaController.text = actividad.sistemaUTM.toString();
+      if (actividad.sistemaUTM != null) {
+        _sistemaSeleccionado = actividad.sistemaUTM == 2 ? 'PSAD56' : 'WGS84';
+      }
       _zonaController.text = actividad.zonaUTM?.toString() ?? '';
       _comp01EsteController.text = actividad.utmEste.toString();
       _comp01NorteController.text = actividad.utmNorte.toString();
@@ -143,7 +144,8 @@ class _ActividadMineraReinfoPaginaState
       origen: Origen.reinfo,
       idTipoActividad: _tipoSeleccionado!.id,
       idSubTipoActividad: _subTipoSeleccionado!.id,
-      sistemaUTM: int.tryParse(_sistemaController.text) ?? 0,
+      sistemaUTM:
+          _sistemaSeleccionado == 'PSAD56' ? 2 : 1,
       utmEste: double.tryParse(_comp01EsteController.text) ?? 0,
       utmNorte: double.tryParse(_comp01NorteController.text) ?? 0,
       zonaUTM: int.tryParse(_zonaController.text),
@@ -284,12 +286,18 @@ class _ActividadMineraReinfoPaginaState
                   ),
                 ),
               ),
-              TextFormField(
-                controller: _sistemaController,
+              DropdownButtonFormField<String>(
+                value: _sistemaSeleccionado,
                 decoration: const InputDecoration(
-                  labelText: 'Sistema UTM',
+                  labelText: 'WGS84/PSAD56',
                   border: OutlineInputBorder(),
                 ),
+                items: const [
+                  DropdownMenuItem(value: 'WGS84', child: Text('WGS84')),
+                  DropdownMenuItem(value: 'PSAD56', child: Text('PSAD56')),
+                ],
+                onChanged: (value) =>
+                    setState(() => _sistemaSeleccionado = value ?? 'WGS84'),
               ),
               const SizedBox(height: 16),
               TextFormField(

--- a/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
+++ b/test/features/actividad/actividad_minera_reinfo_pagina_test.dart
@@ -138,7 +138,7 @@ void main() {
     await tester.tap(find.text('Explotación').last);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.tap(find.bySemanticsLabel('Tipo de Explotación'));
     await tester.pumpAndSettle();
 
     expect(find.text('Aluvial'), findsOneWidget);
@@ -198,7 +198,7 @@ void main() {
     await tester.tap(find.text('Explotación').last);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.tap(find.bySemanticsLabel('Tipo de Explotación'));
     await tester.pumpAndSettle();
     expect(find.text('Aluvial'), findsOneWidget);
     expect(find.text('Filoniano'), findsOneWidget);
@@ -210,7 +210,7 @@ void main() {
     await tester.tap(find.text('Beneficio').last);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.tap(find.bySemanticsLabel('Tipo de Beneficio'));
     await tester.pumpAndSettle();
     expect(find.text('Gravimétrico'), findsOneWidget);
     expect(find.text('Lixiviación'), findsOneWidget);
@@ -237,7 +237,7 @@ void main() {
     await tester.tap(find.text('Explotación').last);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.tap(find.bySemanticsLabel('Tipo de Explotación'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Aluvial').last);
     await tester.pumpAndSettle();
@@ -296,7 +296,7 @@ void main() {
     await tester.tap(find.text('Explotación').last);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.tap(find.bySemanticsLabel('Tipo de Explotación'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Aluvial').last);
     await tester.pumpAndSettle();
@@ -334,7 +334,7 @@ void main() {
           origen: Origen.reinfo,
           idTipoActividad: 1,
           idSubTipoActividad: 2,
-          sistemaUTM: 18,
+          sistemaUTM: 1,
           utmEste: 100,
           utmNorte: 200,
           zonaUTM: 19,
@@ -378,14 +378,13 @@ void main() {
         find.byType(DropdownButtonFormField<TipoActividad>));
     //expect(tipoField.value?.id, 1);
 
-    final subTipoField =
-        tester.widget<DropdownButtonFormField<String>>(find.byType(
-            DropdownButtonFormField<String>));
-    //expect(subTipoField.value, 'Filoniano');
+    final subTipoField = tester.widget<DropdownButtonFormField<SubTipoActividad>>(
+        find.bySemanticsLabel('Tipo de Explotación'));
+    //expect(subTipoField.value?.id, 2);
 
-    final sistemaField =
-        tester.widget<TextFormField>(find.bySemanticsLabel('Sistema UTM'));
-    expect(sistemaField.controller?.text, '18');
+    final sistemaField = tester
+        .widget<DropdownButtonFormField<String>>(find.bySemanticsLabel('WGS84/PSAD56'));
+    expect(sistemaField.value, 'WGS84');
   });
 }
 


### PR DESCRIPTION
## Summary
- replace "Sistema UTM" text field with WGS84/PSAD56 dropdown
- update REINFO page tests for new coordinate selector

## Testing
- `dart format lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart test/features/actividad/actividad_minera_reinfo_pagina_test.dart` *(failed: command not found: dart)*
- `flutter format lib/features/flujo_visita/presentacion/paginas/actividad_minera_reinfo_pagina.dart test/features/actividad/actividad_minera_reinfo_pagina_test.dart` *(failed: command not found: flutter)*
- `flutter test test/features/actividad/actividad_minera_reinfo_pagina_test.dart` *(failed: command not found: flutter)*
- `dart test test/features/actividad/actividad_minera_reinfo_pagina_test.dart` *(failed: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68ac912a9f2c8331bd4040d95b291524